### PR TITLE
Teach reportUrl to respect AWS Region Endpoints

### DIFF
--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -164,7 +164,7 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
       .then(items => {
         const indexFile = items.find(item => item.path.endsWith("index.html"));
         // FIXME is this naming rule correct?
-        const reportUrl = indexFile && `https://s3.amazonaws.com/${this._pluginConfig.bucketName}/${key}/${indexFile.path}`;
+        const reportUrl = indexFile && `${this._s3client.endpoint.href}${this._pluginConfig.bucketName}/${key}/${indexFile.path}`;
         return { reportUrl, items };
       })
       .then(result => {


### PR DESCRIPTION
`https://s3.amazonaws.com/bucket` is only applicable to the default, US East (N. Virginia) region.

When using a bucket created in another region (e.g. `export AWS_REGION=eu-west-1` or by using a profile), clicking on the report link will result in following error:

```xml
<Error>
<Code>PermanentRedirect</Code>
<Message>
The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
</Message>
<Bucket>mymaths-player-visreg</Bucket>
<Endpoint>mymaths-player-visreg.s3.amazonaws.com</Endpoint>
<RequestId>BBB688EBF6359B85</RequestId>
<HostId>
qGm+crinY/ipeRB5YP8m2KfrKYX2ISHFp7Jl0oVI8QtdDsGfd3qso9UDvjqa2b5CCmXBsLuyJ/0=
</HostId>
</Error>
```