### PR TITLE
Modify report url to hosted-style endpoint.

### DIFF
--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -163,7 +163,7 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
       })
       .then(items => {
         const indexFile = items.find(item => item.path.endsWith("index.html"));
-        const reportUrl = indexFile && `${this._s3client.endpoint.href}${this._pluginConfig.bucketName}/${key}/${indexFile.path}`;
+        const reportUrl = indexFile && `https://${this._pluginConfig.bucketName}.s3.amazonaws.com/${key}/${indexFile.path}`;
         return { reportUrl, items };
       })
       .then(result => {


### PR DESCRIPTION
### Overview of the problem

I can not see the report in the displayed URL.I guess that I used an existing `ap-northeast-1` region bucket without using `s3-bucket-preparer`.

### Expected behavior

Display `https://s3-ap-northeast-1.amazonaws.com/[MY_BUCKET_NAME]/COMMIT_HASH/index.html`(path-style) or 
`https:///[MY_BUCKET_NAME].s3.amazonaws.com/COMMIT_HASH/index.html`(hosted-style)

### Actual behavior

Display `https://s3.amazonaws.com/[MY_BUCKET_NAME]/COMMIT_HASH/index.html`

### Description

If using US standard (US West (N. California)) region, we can access to report by following endpoint.

`https://s3.amazonaws.com/[MY_BUCKET_NAME]//COMMIT_HASH/index.html`

However we use other region, we can not access report.Therefore we should probably use `hosted-style` or `path-style` endpoint.
I think `hosted-style` is better than `path-style`, because it does not have to know bucket region.

http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html






