### PR TITLE
Additional engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
 - `actualDir` - *Required* - A directory which contains image files you want to test.
 - `workingDir` - *Optional* - A directory used by reg-suit puts temporary files. Ordinarily this dir is in listed at `.gitignore`.
 - `threshold` - *Optional* - Pixel matching threshold. It should be in ranges from `0` to `1`.
-- `ximgdiffConfig` - *Optional* - An option to display more detailed difference information to report html.
-- `ximgdiffConfig.invocationType` - If set `"cli"`, reg-suit runs x-img-diff-js and detects differences (CLI). If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
+- `ximgdiff` - *Optional* - An option to display more detailed difference information to report html.
+- `ximgdiff.invocationType` - If set `"cli"`, reg-suit runs x-img-diff-js and detects differences (CLI). If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
 
 ### `plugins`
 Entries of `plugins` section are described as key-value pairs. Each key should be plugin name. If you want configurable value, see README.md under the each plugin package(e.g. [packages/reg-publish-s3-plugin/README.md](https://github.com/reg-viz/reg-suit/tree/master/packages/reg-publish-s3-plugin/README.md)).

--- a/README.md
+++ b/README.md
@@ -105,12 +105,17 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
   actualDir: string;      
   workingDir?: string;    // default ".reg"
   threshold?: number;     // default 0
+  ximgdiff?: {
+    invocationType: "none" | "client";  // default "client" 
+  };
 }
 ```
 
 - `actualDir` - *Required* - A directory which contains image files you want to test.
 - `workingDir` - *Optional* - A directory used by reg-suit puts temporary files. Ordinarily this dir is in listed at `.gitignore`.
 - `threshold` - *Optional* - Pixel matching threshold. It should be in ranges from `0` to `1`.
+- `ximgdiffConfig` - *Optional* - An option to display more detailed difference information to report html.
+- `ximgdiffConfig.invocationType` - If set `"cli"`, reg-suit runs x-img-diff-js and detects differences (CLI). If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
 
 ### `plugins`
 Entries of `plugins` section are described as key-value pairs. Each key should be plugin name. If you want configurable value, see README.md under the each plugin package(e.g. [packages/reg-publish-s3-plugin/README.md](https://github.com/reg-viz/reg-suit/tree/master/packages/reg-publish-s3-plugin/README.md)).
@@ -136,6 +141,14 @@ reg-suit run
 #   "bucketName": "my-bucket"
 # }
 ```
+
+### Smart difference detection
+If you turn `core.ximgdiff` option on in `regconfig.json`, reg-suit outputs a report with x-img-diff-js.
+
+[x-img-diff-js](https://reg-viz.github.io/x-img-diff-js) is a difference detection engine which calculates more structural information than naive pixel based comparison result.
+reg-suit use this to display which parts of testing image were inserted or moved.
+
+If `invocationType` is set to `"client"`, x-img-diff-js works on your web browser (It uses Web Assembly and Web Workers, so you need "modern" browser).
 
 ## Run with CI service
 A working demonstration is [here](https://github.com/reg-viz/reg-simple-demo).

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "glob": "^7.1.2",
-    "reg-cli": "0.10.1",
     "tslint-eslint-rules": "^4.1.1"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "glob": "^7.1.2",
+    "reg-cli": "0.10.1",
     "tslint-eslint-rules": "^4.1.1"
   },
   "workspaces": [

--- a/packages/reg-suit-cli/src/commands/prepare.ts
+++ b/packages/reg-suit-cli/src/commands/prepare.ts
@@ -23,7 +23,9 @@ function prepareCore(core: RegSuitCore) {
     return q;
   })).then((conf: any) => {
     // inquirer input returns string, but threshold should be type as number, so cast it.
-    return { ...conf, threshold: +conf.threshold } as CoreConfig;
+    return { ...conf, threshold: +conf.threshold, ximgdiff: {
+      invocationType: "client",
+    } } as CoreConfig;
   })
   ;
 }

--- a/packages/reg-suit-core/package.json
+++ b/packages/reg-suit-core/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "cpx": "^1.5.0",
-    "reg-cli": "^0.10.0",
+    "reg-cli": "^0.10.5",
     "reg-suit-util": "^0.5.9",
     "rimraf": "^2.6.1"
   },

--- a/packages/reg-suit-core/package.json
+++ b/packages/reg-suit-core/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "cpx": "^1.5.0",
-    "reg-cli": "^0.9.0",
+    "reg-cli": "^0.10.0",
     "reg-suit-util": "^0.5.9",
     "rimraf": "^2.6.1"
   },

--- a/packages/reg-suit-interface/src/core.ts
+++ b/packages/reg-suit-interface/src/core.ts
@@ -1,7 +1,12 @@
+export type AdditionalDetectionInvocationType = "none" | "cli" | "client";
+
 export interface CoreConfig {
   actualDir: string;
   workingDir: string;
   threshold?: number;
+  ximgdiff?: {
+    invocationType: AdditionalDetectionInvocationType;
+  };
 }
 
 export interface WorkingDirectoryInfo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6964,12 +6964,12 @@ redux@^3.4.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
-reg-cli@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/reg-cli/-/reg-cli-0.9.0.tgz#bfa13fa24fca175a24039c231b676f3593e49a34"
+reg-cli@0.10.1, reg-cli@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/reg-cli/-/reg-cli-0.10.1.tgz#109bc4447939529c06eb8ed01d2d0a27153938e7"
   dependencies:
     bluebird "^3.5.0"
-    chalk "^2.0.0"
+    chalk "^2.1.0"
     cli-spinner "^0.2.6"
     cross-spawn "^5.1.0"
     glob "^7.1.2"
@@ -6979,6 +6979,7 @@ reg-cli@^0.9.0:
     md5-file "^3.1.1"
     meow "^3.7.0"
     mustache "^2.3.0"
+    x-img-diff-js latest
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -8944,6 +8945,10 @@ ws@1.1.1:
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
+x-img-diff-js@latest:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.1.2.tgz#ce33cd55c6b6d3843005a6bda146a47e134943a9"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6964,9 +6964,9 @@ redux@^3.4.0:
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
 
-reg-cli@0.10.1, reg-cli@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/reg-cli/-/reg-cli-0.10.1.tgz#109bc4447939529c06eb8ed01d2d0a27153938e7"
+reg-cli@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/reg-cli/-/reg-cli-0.10.5.tgz#a77f83154a4b7de96088b5f462caebe92c3a96ab"
   dependencies:
     bluebird "^3.5.0"
     chalk "^2.1.0"
@@ -6979,7 +6979,7 @@ reg-cli@0.10.1, reg-cli@^0.10.0:
     md5-file "^3.1.1"
     meow "^3.7.0"
     mustache "^2.3.0"
-    x-img-diff-js latest
+    x-img-diff-js "^0.1.4"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -8946,9 +8946,9 @@ wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
 
-x-img-diff-js@latest:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.1.2.tgz#ce33cd55c6b6d3843005a6bda146a47e134943a9"
+x-img-diff-js@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.1.4.tgz#d956bd098d95c8d11788ce35a399cf199e6e428c"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A part work of https://github.com/reg-viz/reg-cli/issues/90 .

>  Hoist the above option to reg-suit/core option. User can set this using regconfig.json

I introduce `ximgdiff` option to `core` config, and set the invocation type value `client`. 
But this option is extremely experimental. So If you prefer turning it off by default, I change it so.

And I modify S3 plugin:

- publish `.js` and `.wasm` too
- upload/download using `ContentEncoding: gzip` header. Because it's too slow to download no-compressed WASM file from S3...