### PR TITLE
Enable to specify ACL

### DIFF
--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -14,6 +14,7 @@ import { PublisherPlugin,
 export interface PluginConfig {
   bucketName: string;
   pattern?: string;
+  acl?: string;
 }
 
 interface PluginConfigInternal extends PluginConfig {
@@ -195,7 +196,7 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
             Body: data,
             ContentType: item.mimeType,
             ContentEncoding: "gzip",
-            ACL: "public-read",
+            ACL: this.pluginConfig.acl || "public-read",
           }, (err, x) => {
             if (err) return reject(err);
             this._logger.verbose(`Uploaded from ${item.absPath} to ${key}/${item.path}`,);


### PR DESCRIPTION
Hi!

I use reg-suit in my products and a company, thank you 😄 

However we can't publish report whose ACL is `public-read`.
So I am glad if we enable to specify `private` to `acl` property in config like..

```
"reg-publish-s3-plugin": {
    "bucketName": "sample-bucket",
    "acl": "private"
}
```

Best regards.
