### PR TITLE
Make `@types/inquirer` a regular dependency

### DIFF
--- a/packages/reg-suit-interface/package.json
+++ b/packages/reg-suit-interface/package.json
@@ -16,8 +16,10 @@
   },
   "repository": "git+https://github.com/reg-viz/reg-suit.git",
   "license": "MIT",
+  "dependencies": {
+    "@types/inquirer": "^0.0.35"
+  },
   "devDependencies": {
-    "@types/inquirer": "^0.0.35",
     "typescript": "~2.5.3"
   }
 }


### PR DESCRIPTION
`reg-suit-interface` exports `lib/plugin.d.ts`, which references `inquirer`. Since `inquirer` is a dev dependency, though, TypeScript chokes on the reference, because `@types/inquirer` isn't installed in libraries that depend on `reg-suit-interface`.