### PR TITLE
Remove checkCredential to get credentials from EC2 instance metadata service

### DIFF
--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -52,7 +52,6 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
     this._s3client = new S3();
     this._noEmit = config.noEmit;
     this._logger = config.logger;
-    this._checkCredentials();
   }
 
   createList(): Promise<FileItem[]> {
@@ -174,14 +173,6 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
         return result;
       })
     ;
-  }
-
-  private _checkCredentials() {
-    if (!awsConfig.credentials || !awsConfig.credentials.accessKeyId || !awsConfig.credentials.secretAccessKey) {
-      this._logger.error("Failed to read AWS credentials.");
-      this._logger.error(`Create ${this._logger.colors.magenta("~/.aws/credentials")} or export ${this._logger.colors.green("$AWS_ACCESS_KEY_ID")} and ${this._logger.colors.green("$AWS_SECRET_ACCESS_KEY")}.`);
-      throw new Error("AWS credentials are not set.");
-    }
   }
 
   private _publishItem(key: string, item: FileItem): Promise<FileItem> {

--- a/packages/reg-suit-core/src/processor.ts
+++ b/packages/reg-suit-core/src/processor.ts
@@ -197,6 +197,10 @@ export class RegProcessor {
         .catch(reason => {
           // re-throw notifiers error because it's fatal.
           this._logger.error("An error occurs during publishing snapshot:");
+          if (reason.code === "CredentialsError") {
+            this._logger.error("Failed to read AWS credentials.");
+            this._logger.error(`Create ${this._logger.colors.magenta("~/.aws/credentials")} or export ${this._logger.colors.green("$AWS_ACCESS_KEY_ID")} and ${this._logger.colors.green("$AWS_SECRET_ACCESS_KEY")}.`);
+          }
           if (reason) this._logger.error(reason);
           return Promise.reject<StepResultAfterPublish>(reason);
         })


### PR DESCRIPTION
Hi :) I want to use `Credentials from Instance Metadata` in EC2 instance.(please see. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials). In this case, credentials are automatically obtained from  EC2 instance metadata service via `aws-sdk`.

However, when using this way, `_checkCredential` will fail in the current version. So, I think that it is better to delegate authentication processing to `aws-sdk`package.

Do you have any thoughts?





