### PR TITLE
Support for large number of screenshots (> 1,000) in reg-publish-s3-plugin.

### DIFF
--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -106,9 +106,11 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
         try {
           result = await this._listObjectsPromise(nextMarker, actualPrefix)
           let curContents = result.Contents || []
-          nextMarker = curContents[curContents.length - 1].Key || ''
+          if (curContents.length > 0) {
+            nextMarker = curContents[curContents.length - 1].Key || ''
+            Array.prototype.push.apply(contents, curContents)
+          }
           isTruncated = result.IsTruncated || false;
-          Array.prototype.push.apply(contents, curContents)
         } catch(e) {
           reject(e)
         }

--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -21,6 +21,10 @@ interface PluginConfigInternal extends PluginConfig {
   pattern: string;
 }
 
+interface S3ListObjectContent {
+  Key?: string;
+}
+
 export interface FileItem {
   path: string;
   absPath: string;
@@ -90,19 +94,28 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
     if (this._noEmit) return Promise.resolve();
     const actualPrefix = `${key}/${path.basename(this._options.workingDirs.actualDir)}`;
     const progress = this._logger.getProgressBar();
-    return new Promise<S3.ListObjectsOutput>((resolve, reject) => {
-      this._s3client.listObjects({
-        Bucket: this._pluginConfig.bucketName,
-        Prefix: actualPrefix,
-        MaxKeys: 3000,
-      }, (err, x) => {
-        if (err) {
-          return reject(err);
+    return new Promise<S3ListObjectContent []>(async (resolve, reject) => {
+      let contents: S3ListObjectContent [] = []
+      let isTruncated: boolean = true
+      let nextMarker: string = ''
+
+      const maxLoop = 3
+      let loop = 0
+      while (isTruncated && loop < maxLoop) {
+        let result: S3.ListObjectsOutput;
+        try {
+          result = await this._listObjectsPromise(nextMarker, actualPrefix)
+          let curContents = result.Contents || []
+          nextMarker = curContents[curContents.length - 1].Key || ''
+          isTruncated = result.IsTruncated || false;
+          Array.prototype.push.apply(contents, curContents)
+        } catch(e) {
+          reject(e)
         }
-        resolve(x);
-      });
+        loop += 1
+      }
+      resolve(contents)
     })
-    .then(result => result.Contents || [])
     .then(contents => {
       if (contents.length) {
         progress.start(contents.length, 0);
@@ -230,5 +243,31 @@ export class S3PublisherPlugin implements PublisherPlugin<PluginConfig> {
     } else {
       cb(null, output.Body as Buffer);
     }
+  }
+
+  private _listObjectsPromise(lastKey: string, prefix: string): Promise<S3.ListObjectsOutput> {
+    interface S3ListObjectsOptions {
+      Bucket: string;
+      Prefix: string;
+      MaxKeys: number;
+      Marker?: string;
+    }
+    let options: S3ListObjectsOptions = {
+      Bucket: this._pluginConfig.bucketName,
+      Prefix: prefix,
+      MaxKeys: 1000,
+    }
+    if (lastKey) {
+        options.Marker = lastKey
+    }
+
+    return new Promise<S3.ListObjectsOutput>((resolve, reject) => {
+      this._s3client.listObjects(options, async (err, result: S3.ListObjectsOutput) => {
+        if (err) {
+          reject(err)
+        }
+        resolve(result)
+      })
+    })
   }
 }


### PR DESCRIPTION
Hi, thank you for your great projects. reg-suit is very easy to use and a nice tool for visual regression testing.

I used reg-suit for web services with more than 1,000 pages. 
Then, I found the following behavior (maybe bug) about  S3 listObject pagination.
This PR is the fix of the behavior.

# Problem

- Given that the number of screenshots are more than 1,000.
- We can upload them (publish) to S3 with no problem.
- But, we can download only 1,000 screenshots in the next comparison. 

Logs

```
// Actual snapshot directory has 1011 items. (keys are shadowed.)
# aws s3 ls s3://reg-publish-bucket-xxx/yyy/actual/ | wc -l
    1011

// But, we can download only 1,00 items with sync-expected.
# npx reg-suit sync-expected
[reg-suit] info version: 0.7.2
[reg-suit] info Detected the previous snapshot key: 'yyy'
                                         ■ 0% | ETA: 0s | 0/1000[reg-publish-s3-plugin] info Download 1000 files from reg-publish-bucket-xxx.
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 100% | ETA: 0s | 1000/1000
```

# Solution 

The behavior is due to the lack of pagination handling when calling S3.listObject() [here]( https://github.com/reg-viz/reg-suit/blob/master/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts#L93-L104).
In the API reference of S3.listObject(), I found a line saying

```
Returns some or all (up to 1000) of the objects in a bucket. 
```

https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjects-property

Then, I added pagination logic in this PR.
With this changes, I can download more than 1,000 items successfully.

```
// Successfully download more than 1,000 items.
# npx reg-suit sync-expected
[reg-suit] info version: 0.7.2
[reg-suit] info Detected the previous snapshot key: 'yyy'
                                         ■ 0% | ETA: 0s | 0/1011[reg-publish-s3-plugin] info Download 1011 files from reg-publish-bucket-xxx.
 ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 100% | ETA: 1s | 1011/1011
```