### PR TITLE
Replace env vars for core conf

### DIFF
--- a/packages/reg-suit-core/src/config-manager.test.ts
+++ b/packages/reg-suit-core/src/config-manager.test.ts
@@ -15,19 +15,9 @@ function createManager() {
   return new ConfigManager({ logger, noEmit: true });
 }
 
-test("do nothing conf without plugins section", t => {
-  const conf = {
-    core: coreConf,
-  };
-  const manager = createManager();
-  manager._loadedConfig = conf;
-  const actual = manager.replaceEnvValue() as any;
-  t.is(actual, conf);
-});
-
 test("replace placeholders in config", t => {
   const conf = {
-    core: coreConf,
+    core: { actualDir: "$HOGE_FOO", workingDir: "HOGE_FOO" },
     plugins: {
       "some-plugin": { "xxx": "$HOGE_FOO", "yyy": "${HOGE_FOO}", "zzz": "HOGE_FOO" }
     }
@@ -38,6 +28,8 @@ test("replace placeholders in config", t => {
   t.is(actual.plugins["some-plugin"].xxx, process.env["HOGE_FOO"]);
   t.is(actual.plugins["some-plugin"].yyy, process.env["HOGE_FOO"]);
   t.is(actual.plugins["some-plugin"].zzz, "HOGE_FOO");
+  t.is(actual.core.actualDir, process.env["HOGE_FOO"]);
+  t.is(actual.core.workingDir, "HOGE_FOO");
 });
 
 test("replace nested placeholders", t => {

--- a/packages/reg-suit-core/src/config-manager.ts
+++ b/packages/reg-suit-core/src/config-manager.ts
@@ -61,12 +61,10 @@ export class ConfigManager {
 
   replaceEnvValue(): RegSuitConfiguration {
     const rawConfig = this.config;
-    if (!rawConfig.plugins) return rawConfig;
-    const plugins = { ...rawConfig.plugins };
     if (!!((<any>rawConfig)["__replaced__"])) return rawConfig;
-    expandPlaceholders(plugins);
+    expandPlaceholders(rawConfig);
     (<any>rawConfig)["__replaced__"] = true;
-    return { ...rawConfig, plugins };
+    return rawConfig;
   }
 
   get config() {


### PR DESCRIPTION
I want to inject env var to core conf as well.
Is there any reason to restrict this feature for only plugins?