### PR TITLE
Change default config

### DIFF
--- a/packages/reg-suit-core/src/config-manager.ts
+++ b/packages/reg-suit-core/src/config-manager.ts
@@ -78,7 +78,7 @@ export class ConfigManager {
     const defaultCoreConfig = {
       workingDir: ".reg",
       actualDir: "directory_contains_actual_images",
-      threshold: 0,
+      thresholdRate: 0,
     } as CoreConfig;
     let readResult: any, readJsonObj: any;
     const configFilePath = this._getConfigPath();


### PR DESCRIPTION
I got the following config when I ran `reg-suit prepare` with no plugins:

```
$ reg-suit prepare
[reg-suit] info version: 0.7.15
[reg-suit] info Configuration:
[reg-suit] info {
  "core": {
    "workingDir": ".reg",
    "actualDir": "directory_contains_actual_images",
    "threshold": 0
  },
  "plugins": {}
}
```

I was confused what "core.threshold" is because it was replaced with "core.thresholdRate"
and there's no documentation for that.

https://github.com/reg-viz/reg-suit/pull/104

I guess threshold is deprecated so let's change default config.

----

I can't find the way to test for this behavior.
I hope it works but to be honest I'm not sure.