### PR TITLE
Add sdkOptions to s3-publisher-plugin

### DIFF
--- a/packages/reg-publish-s3-plugin/README.md
+++ b/packages/reg-publish-s3-plugin/README.md
@@ -37,6 +37,7 @@ aws_secret_access_key = <your-secret-key>
   sse?: boolean | string;
   customDomain?: string;
   pathPrefix?: string;
+  sdkOptions?: S3.Types.ClientConfiguration;
 }
 ```
 
@@ -45,3 +46,4 @@ aws_secret_access_key = <your-secret-key>
 - `sse` - *Optional* - Specify server-side encryption property. Default `false`. If you set `true`, this plugin send with `--sse="AES256`.
 - `customDomain` - *Optional* - Set if you have your domain and host S3 on it. If set, the HTML report will be published with this custom domain(e.g. `https://your-sub.example.com/...`).
 - `pathPrefix` - *Optional* - Specify paths. For example if you set `some_dir`, the report is published with URL such as `https://your-backet-name.s3.amazonaws.com/some_dir/xxxxxxxxx/index.html`.
+- `sdkOptions` - *Optional* - Specify SDK options to pass to the S3 client. For details about the options, refer to the [AWS JavaScript SDK docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor_details).

--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -14,6 +14,7 @@ export interface PluginConfig {
   sse?: boolean | string;
   customDomain?: string;
   pathPrefix?: string;
+  sdkOptions?: S3.Types.ClientConfiguration;
 }
 
 export class S3PublisherPlugin extends AbstractPublisher implements PublisherPlugin<PluginConfig> {
@@ -34,7 +35,7 @@ export class S3PublisherPlugin extends AbstractPublisher implements PublisherPlu
     this._pluginConfig = {
       ...config.options,
     };
-    this._s3client = new S3();
+    this._s3client = new S3(this._pluginConfig.sdkOptions);
   }
 
   publish(key: string) {


### PR DESCRIPTION
Hi all. First of all, thank you very much for this awesome and exciting project. I'm really looking forward to use this in my daily workflow.

I wondered whether to just open an issue or create a PR but have decided to create a PR because I've tested the following change locally.

## Description

Added ability to inject sdk options into the S3 client via regconfig.json.

## Motivation and Context

Currently, the S3 client is created without any sdk options, hence custom configs cannot be injected. Generally this probably isn't a problem, but I've wanted to test the functionality with [minio](https://github.com/minio/minio), a S3 API compatible object storage server. In order for this to work, I need to inject the following options to the S3 client.

```json
{
  "endpoint": "<THE ENDPOINT TO THE MINIO SERVER>",
  "s3ForcePathStyle": true,
  "signatureVersion": "v4"
}
```

Therefore, I've added a `sdkOptions` key with the `S3.Types.ClientConfiguration` type to be compatible with the S3 client options. The following is a sample `regconfig.json` file:

```json
{
  "core": {
    "workingDir": ".reg",
    "actualDir": "screenshot",
    "threshold": 0,
    "ximgdiff": {
      "invocationType": "client"
    }
  },
  "plugins": {
    "reg-keygen-git-hash-plugin": true,
    "reg-notify-github-plugin": {
      "clientId": "MzQ0tDAzNzIz0S9KTdctKC0oSC1JTS3STUnNzdc3MTA0gkiUZVYBAA=="
    },
    "reg-publish-s3-plugin": {
      "bucketName": "static",
      "customDomain": "localhost:8080",
      "sdkOptions": {
        "endpoint": "http://127.0.0.1:9000",
        "s3ForcePathStyle": true,
        "signatureVersion": "v4"
      }
    }
  }
}
```

> Note: Since the `Report URL` protocol is hard coded to `https`, the auto generated URL won't work out of the box. (e.g. `[reg-suit] info Report URL: https://localhost:8080/7d909e74fb9ce2ac8fd89c022d4bcb72f642c2d6/index.html` )

There are things to be considered (the key name `sdkOptions`, the way `this._pluginConfig.sdkOptions` is being passed) but I'm assuming there are some needs for this feature.

## How Has This Been Tested?

I've tested this locally with a minio server running on my laptop via Docker. Since minio cannot host websites like S3, I've added nginx to view the results. The following capture shows the results via the local nginx server.

![image](https://user-images.githubusercontent.com/3941889/48423996-0c7def00-e7a5-11e8-830c-7facac6f1d26.png)
 
If there are any more additional information I should add, I'll be more than happy to provide it. Thanks!