### PR TITLE
Use opn over open

### DIFF
--- a/packages/reg-notify-github-plugin/package.json
+++ b/packages/reg-notify-github-plugin/package.json
@@ -29,7 +29,7 @@
     "typescript": "2.8.1"
   },
   "dependencies": {
-    "open": "^0.0.5",
+    "opn": "^5.4.0",
     "reg-suit-util": "^0.7.16",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",

--- a/packages/reg-notify-github-plugin/src/github-preparer.ts
+++ b/packages/reg-notify-github-plugin/src/github-preparer.ts
@@ -8,7 +8,7 @@ import {
 
 import { GitHubPluginOption } from "./github-notifier-plugin";
 
-const open = require("open") as (url: string) => void;
+const opn = require("opn");
 
 export interface GitHubPreparerOption {
   clientId: string;
@@ -28,7 +28,7 @@ export class GitHubPreparer implements PluginPreparer<GitHubPreparerOption, GitH
         message: "This repositoriy's client ID of reg-suit GitHub app",
         name: "clientId",
         when: ({ openApp }: any) => {
-          openApp && open("https://reg-viz.github.io/reg-suit/gh-app/");
+          openApp && opn("https://reg-viz.github.io/reg-suit/gh-app/");
           return true;
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6705,10 +6705,6 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-open@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
-
 openurl@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
@@ -6729,6 +6725,13 @@ opn@^5.0.0:
 opn@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.2.0.tgz#71fdf934d6827d676cecbea1531f95d354641225"
+  dependencies:
+    is-wsl "^1.1.0"
+
+opn@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
+  integrity sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
Opn is safer and actively maintained. Also, `npm/yarn audit` marks `open` as a critical vulnerability.