### PR TITLE
fix: typo publishInteral to publishInternal

### DIFF
--- a/packages/reg-publish-gcs-plugin/src/gcs-publisher-plugin.ts
+++ b/packages/reg-publish-gcs-plugin/src/gcs-publisher-plugin.ts
@@ -33,7 +33,7 @@ export class GcsPublisherPlugin extends AbstractPublisher implements PublisherPl
   }
 
   async publish(key: string) {
-    const { indexFile } = await this.publishInteral(key);
+    const { indexFile } = await this.publishInternal(key);
     const reportUrl = indexFile && `https://storage.googleapis.com/${this.getBucketName()}/${this.resolveInBucket(key)}/${indexFile.path}`;
     return { reportUrl };
   }

--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -39,7 +39,7 @@ export class S3PublisherPlugin extends AbstractPublisher implements PublisherPlu
   }
 
   publish(key: string) {
-    return this.publishInteral(key).then(({ indexFile }) => {
+    return this.publishInternal(key).then(({ indexFile }) => {
       const reportUrl = indexFile && `https://${this.getBucketDomain()}/${this.resolveInBucket(key)}/${indexFile.path}`;
       return { reportUrl };
     });

--- a/packages/reg-suit-util/src/cloud-storage-util.ts
+++ b/packages/reg-suit-util/src/cloud-storage-util.ts
@@ -142,7 +142,7 @@ export abstract class AbstractPublisher {
     ;
   }
 
-  protected publishInteral(key: string) {
+  protected publishInternal(key: string) {
     const progress = this.logger.getProgressBar();
     return this.createList()
       .then(list => {


### PR DESCRIPTION
## What does this change?

Renamed a function, which has a strange name. It seems just a typo because there is an inconsistency between `fetchInternal` and `publishInteral`.

## References

- I found this while trying to fix this issue #174 (I'm happy if you could check it too 😉)

## Screenshots

No screenshots for this change.

## What can I check for bug fixes?

I think it's ok not to check the behavior if you check the tsc compile succeed.
