### PR TITLE
Allow branchName in reg-notify-github-plugin config

### DIFF
--- a/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
+++ b/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
@@ -19,6 +19,7 @@ export interface GitHubPluginOption {
   installationId?: string;
   owner?: string;
   repository?: string;
+  branchName?: string;
   prComment?: boolean;
   setCommitStatus?: boolean;
   customEndpoint?: string;
@@ -128,12 +129,12 @@ export class GitHubNotifierPlugin implements NotifierPlugin<GitHubPluginOption> 
     }
 
     if (this._prComment) {
-      if (head.type === "branch" && head.branch) {
+      if (head.type === "branch" && (head.branch || this._apiOpt.branchName)) {
         const prCommentBody: CommentToPrBody = {
           ...this._apiOpt,
-          branchName: head.branch.name,
           failedItemsCount, newItemsCount, deletedItemsCount, passedItemsCount,
         };
+        if (!prCommentBody.branchName && head.branch) prCommentBody.branchName = head.branch.name;
         if (params.reportUrl) prCommentBody.reportUrl = params.reportUrl;
         const commentReq: rp.OptionsWithUri = {
           uri: `${this._apiPrefix}/api/comment-to-pr`,


### PR DESCRIPTION
## What does this change?

Allows setting a branch name in the config, enabling something like

```
  "reg-notify-github-plugin": {
    "branchName": "$GIT_BRANCH_NAME"
  }
```

This enables a GitHub workflow where there is no deep clone or re-fetch, and the commit shas are all received from Github context, e.g.

```
      - name: Compare screenshots
        if: github.event_name == 'pull_request'
        env:
          REG_SUIT_EXPECTED_KEY: ${{ github.event.pull_request.base.sha }}
          REG_SUIT_ACTUAL_KEY: ${{ github.event.pull_request.head.sha }}
       run: ... compare

      - name: Publish results
        if: github.event_name == 'pull_request'
        env:
          REG_SUIT_EXPECTED_KEY: ${{ github.event.pull_request.base.sha }}
          REG_SUIT_ACTUAL_KEY: ${{ github.event.pull_request.head.sha }}
          REG_SUIT_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
       run: ... publish
``` 