### PR TITLE
Add enableAntialias flag to core config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
   workingDir?: string;        // default ".reg"
   thresholdRate?: number;    // default 0
   thresholdPixel?: number;    // default 0
+  enableAntialias?: boolean;    // default false
   ximgdiff?: {
     invocationType: "none" | "client";  // default "client" 
   };
@@ -125,6 +126,7 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
 - `thresholdRate` - *Optional* - Threshold of the ratio of the number of pixels where the difference occurred to the whole. It should be in ranges from `0` to `1`.
 - `thresholdPixel` - *Optional* - Alternative threshold. The absolute number of pixels where difference occurred.
 - `matchingThreshold` - *Optional* - Matching threshold for YUV color distance between two pixels. It should be in ranges from 0 to 1. Smaller values make the comparison more sensitive.
+- `enableAntialias` - *Optional* - Enable antialias, so that anti-aliased pixels are detected and ignoring when comparing images.
 - `ximgdiff` - *Optional* - An option to display more detailed difference information to report html.
 - `ximgdiff.invocationType` - If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
 - `thresholdRate` - *Optional* - Threshold of the ratio of the number of pixels where the difference occurred to the whole. It should be in ranges from `0` to `1`.
 - `thresholdPixel` - *Optional* - Alternative threshold. The absolute number of pixels where difference occurred.
 - `matchingThreshold` - *Optional* - Matching threshold for YUV color distance between two pixels. It should be in ranges from 0 to 1. Smaller values make the comparison more sensitive.
-- `enableAntialias` - *Optional* - Enable antialias, so that anti-aliased pixels are detected and ignoring when comparing images.
+- `enableAntialias` - *Optional* - Enable antialias, so that anti-aliased pixels are detected and ignored when comparing images.
 - `ximgdiff` - *Optional* - An option to display more detailed difference information to report html.
 - `ximgdiff.invocationType` - If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
 

--- a/packages/reg-suit-core/src/processor.ts
+++ b/packages/reg-suit-core/src/processor.ts
@@ -119,6 +119,7 @@ export class RegProcessor {
       thresholdPixel: this._config.thresholdPixel,
       thresholdRate: this._config.thresholdRate,
       matchingThreshold: this._config.matchingThreshold,
+      enableAntialias: this._config.enableAntialias,
       enableCliAdditionalDetection: ximgdiffConf.invocationType === "cli",
       enableClientAdditionalDetection: ximgdiffConf.invocationType !== "none",
     }) as EventEmitter;

--- a/packages/reg-suit-interface/src/core.ts
+++ b/packages/reg-suit-interface/src/core.ts
@@ -7,6 +7,7 @@ export interface CoreConfig {
   thresholdPixel?: number;
   thresholdRate?: number;
   matchingThreshold?: number;
+  enableAntialias?: boolean;
   ximgdiff?: {
     invocationType: AdditionalDetectionInvocationType;
   };


### PR DESCRIPTION
## What does this change?

Added the flag `enableAntialias` to the core config, so that it's configurable if anti-aliased pixels are detected and ignored when comparing images, or not.

## References

https://github.com/mapbox/pixelmatch/blob/38b395747e583e6932a13f80d17d4cb7a606c742/index.js#L60
