### PR TITLE
add discussion to commentTo option

### DIFF
--- a/packages/reg-notify-gitlab-plugin/README.md
+++ b/packages/reg-notify-gitlab-plugin/README.md
@@ -17,14 +17,14 @@ reg-suit prepare -p notify-gitlab
   projectId: string;
   privateToken: string;
   gitlabUrl?: string;
-  commentTo?: "note" | "description";
+  commentTo?: "note" | "description" | "discussion";
 }
 ```
 
 - `projectId` - *Required* - Your GitLab project id. You can get this id via `https://gitlab.com/<your-name>/<your-project-name/edit>` page.
 - `privateToken` - *Required* - Your GitLab API token. If you want more detail, see [Personal access tokens doc](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 - `gitlabUrl` - *Optional* - Set if you host your GitLab instance. Default: `https://gitlab.com`
-- `commentTo` - *Optional* - How this plugin comments to MR. If `"note"`, it posts or puts the comment as a MR's note. if `"description"`, your MR's description gets updated. Default: `"note"`.
+- `commentTo` - *Optional* - How this plugin comments to MR. If `"note"`, it posts or puts the comment as a MR's note. if `"description"`, your MR's description gets updated. If `"discussion"`, it posts or puts the comment as a MR's *resolvable* note. Default: `"note"`.
 
 ### Auto complete on GitLab CI
 

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-api-client.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-api-client.ts
@@ -1,6 +1,7 @@
 export type ProjectIdType = number;
 export type MergeResuestIidType = number;
 export type NoteIdType = number;
+export type DiscussionIdType = number;
 import * as rp from "request-promise";
 
 export type MergeRequestResource = {
@@ -16,6 +17,11 @@ export type CommitResource = {
 export type NoteResouce = {
   id: NoteIdType;
   body: string;
+};
+
+export type DiscussionResource = {
+  id: DiscussionIdType;
+  notes: NoteResouce[];
 };
 
 export type GetMergeRequestsParams = {
@@ -51,6 +57,12 @@ export type PutMergeRequestNoteParams = {
   body: string;
 };
 
+export type PostMergeRequestDiscussionParams = {
+  project_id: ProjectIdType;
+  merge_request_iid: MergeResuestIidType;
+  body: string;
+};
+
 export interface GitLabApiClient {
   getMergeRequests(params: GetMergeRequestsParams): Promise<MergeRequestResource[]>;
   putMergeRequest(params: PutMergeRequestParams): Promise<MergeRequestResource>;
@@ -58,6 +70,7 @@ export interface GitLabApiClient {
   getMergeRequestNotes(params: GetMergeRequestNotesParams): Promise<NoteResouce[]>;
   postMergeRequestNote(params: PostMergeRequestNoteParams): Promise<NoteResouce>;
   putMergeRequestNote(params: PutMergeRequestNoteParams): Promise<NoteResouce>;
+  postMergeRequestDiscussion(params: PostMergeRequestDiscussionParams): Promise<DiscussionResource>;
 }
 
 export class DefaultGitLabApiClient implements GitLabApiClient {
@@ -145,4 +158,18 @@ export class DefaultGitLabApiClient implements GitLabApiClient {
     return (rp(reqParam) as any) as Promise<NoteResouce>;
   }
 
+  postMergeRequestDiscussion(params: PostMergeRequestDiscussionParams): Promise<DiscussionResource> {
+    const reqParam: rp.OptionsWithUrl = {
+      method: "POST",
+      url: `${this._urlPrefix}/api/v4/projects/${params.project_id}/merge_requests/${params.merge_request_iid}/discussions`,
+      json: true,
+      headers: {
+        "Private-Token": this._token,
+      },
+      body: {
+        "body": params.body,
+      },
+    };
+    return (rp(reqParam) as any) as Promise<DiscussionResource>;
+  }
 }

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.ts
@@ -5,14 +5,14 @@ import {
   PluginLogger,
 } from "reg-suit-interface";
 import { parse } from "url";
-import { commentToMergeRequests, appendOrUpdateMergerequestsBody } from "./use-cases";
+import { commentToMergeRequests, appendOrUpdateMergerequestsBody, addDiscussionToMergeRequests } from "./use-cases";
 import { DefaultGitLabApiClient } from "./gitlab-api-client";
 
 export interface GitLabPluginOption {
   gitlabUrl?: string;
   projectId?: string;
   privateToken: string;
-  commentTo?: "note" | "description";
+  commentTo?: "note" | "description" | "discussion";
 }
 
 export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> {
@@ -23,7 +23,7 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
   private _gitlabUrl!: string;
   private _projectId!: string | undefined;
   private _token!: string | undefined;
-  private _commentTo: "note" | "description" = "note";
+  private _commentTo: "note" | "description" | "discussion" = "note";
 
   init(config: PluginCreateOptions<GitLabPluginOption>) {
     this._noEmit = config.noEmit;
@@ -68,6 +68,14 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
         notifyParams: params,
         projectId: this._projectId,
       });
+    } else if (this._commentTo === "discussion") {
+      await addDiscussionToMergeRequests({
+        noEmit: this._noEmit,
+        logger: this._logger,
+        client,
+        notifyParams: params,
+        projectId: this._projectId,
+      });      
     } else {
       await commentToMergeRequests({
         noEmit: this._noEmit,

--- a/packages/reg-notify-gitlab-plugin/src/testing/gitlab-fixture-client.ts
+++ b/packages/reg-notify-gitlab-plugin/src/testing/gitlab-fixture-client.ts
@@ -5,6 +5,7 @@ import {
   MergeRequestResource,
   CommitResource,
   NoteResouce,
+  DiscussionResource,
 } from "../gitlab-api-client";
 
 export class GitLabFixtureClient implements GitLabApiClient {
@@ -33,5 +34,8 @@ export class GitLabFixtureClient implements GitLabApiClient {
   }
   putMergeRequestNote(params: { project_id: number; merge_request_iid: number; note_id: number; body: string; }): Promise<NoteResouce> {
     return this.loadFixtue<NoteResouce>("putMergeRequestNote");
+  }
+  postMergeRequestDiscussion(params: { project_id: number; merge_request_iid: number; body: string; }): Promise<DiscussionResource> {
+    return this.loadFixtue<DiscussionResource>("postMergeRequestDiscussion");
   }
 }

--- a/packages/reg-notify-gitlab-plugin/src/use-cases.test.ts
+++ b/packages/reg-notify-gitlab-plugin/src/use-cases.test.ts
@@ -3,7 +3,7 @@ import * as sinon from "sinon";
 import { ComparisonResult } from "reg-suit-interface";
 import { RegLogger } from "reg-suit-util";
 import { GitLabFixtureClient } from "./testing/gitlab-fixture-client";
-import { commentToMergeRequests, appendOrUpdateMergerequestsBody, DESC_BODY_START_MARK, DESC_BODY_END_MARK } from "./use-cases";
+import { commentToMergeRequests, appendOrUpdateMergerequestsBody, DESC_BODY_START_MARK, DESC_BODY_END_MARK, addDiscussionToMergeRequests } from "./use-cases";
 import { PutMergeRequestParams } from "./gitlab-api-client";
 
 function createComparisonResult() {
@@ -85,6 +85,73 @@ test("add comment to MR when the MR already has note this notifiers comment", as
   t.truthy(getMergeRequestsSpy.called);
   t.deepEqual(getMergeRequestCommitsSpy.firstCall.args[0], { project_id: 1234, merge_request_iid: 1 });
   t.falsy(postMergeRequestNoteSpy.called);
+  t.truthy(putMergeRequestNoteSpy.called);
+});
+
+test("nothing discussion post when noEmit: true", async t => {
+  const client = new GitLabFixtureClient("base-no-marked-comment");
+  const logger = new RegLogger();
+  const getMergeRequestsSpy = sinon.spy(client, "getMergeRequests");
+  const postMergeRequestDiscussionSpy = sinon.spy(client, "postMergeRequestDiscussion");
+  const putMergeRequestNoteSpy = sinon.spy(client, "putMergeRequestNote");
+  await addDiscussionToMergeRequests({
+    noEmit: true,
+    client, logger,
+    projectId: "1234",
+    notifyParams: {
+      actualKey: "cbab9a085be8cbcbdbd498d5226479ee5a44c34b",
+      expectedKey: "EXPECTED",
+      comparisonResult: createComparisonResult(),
+    },
+  });
+  t.truthy(getMergeRequestsSpy.called);
+  t.falsy(postMergeRequestDiscussionSpy.called);
+  t.falsy(putMergeRequestNoteSpy.called);
+});
+
+test("add discussion comment to MR when the MR does not have this notifiers comment", async t => {
+  const client = new GitLabFixtureClient("base-no-marked-comment");
+  const logger = new RegLogger();
+  const getMergeRequestsSpy = sinon.spy(client, "getMergeRequests");
+  const getMergeRequestCommitsSpy = sinon.spy(client, "getMergeRequestCommits");
+  const postMergeRequestDiscussionSpy = sinon.spy(client, "postMergeRequestDiscussion");
+  const putMergeRequestNoteSpy = sinon.spy(client, "putMergeRequestNote");
+  await addDiscussionToMergeRequests({
+    noEmit: false,
+    client, logger,
+    projectId: "1234",
+    notifyParams: {
+      actualKey: "cbab9a085be8cbcbdbd498d5226479ee5a44c34b",
+      expectedKey: "EXPECTED",
+      comparisonResult: createComparisonResult(),
+    },
+  });
+  t.truthy(getMergeRequestsSpy.called);
+  t.deepEqual(getMergeRequestCommitsSpy.firstCall.args[0], { project_id: 1234, merge_request_iid: 1 });
+  t.truthy(postMergeRequestDiscussionSpy.called);
+  t.falsy(putMergeRequestNoteSpy.called);
+});
+
+test("update discussion to MR when the MR already has note this notifiers comment", async t => {
+  const client = new GitLabFixtureClient("base-fulfilled");
+  const logger = new RegLogger();
+  const getMergeRequestsSpy = sinon.spy(client, "getMergeRequests");
+  const getMergeRequestCommitsSpy = sinon.spy(client, "getMergeRequestCommits");
+  const postMergeRequestDiscussionSpy = sinon.spy(client, "postMergeRequestDiscussion");
+  const putMergeRequestNoteSpy = sinon.spy(client, "putMergeRequestNote");
+  await addDiscussionToMergeRequests({
+    noEmit: false,
+    client, logger,
+    projectId: "1234",
+    notifyParams: {
+      actualKey: "cbab9a085be8cbcbdbd498d5226479ee5a44c34b",
+      expectedKey: "EXPECTED",
+      comparisonResult: createComparisonResult(),
+    },
+  });
+  t.truthy(getMergeRequestsSpy.called);
+  t.deepEqual(getMergeRequestCommitsSpy.firstCall.args[0], { project_id: 1234, merge_request_iid: 1 });
+  t.falsy(postMergeRequestDiscussionSpy.called);
   t.truthy(putMergeRequestNoteSpy.called);
 });
 

--- a/packages/reg-notify-gitlab-plugin/src/use-cases.ts
+++ b/packages/reg-notify-gitlab-plugin/src/use-cases.ts
@@ -1,4 +1,4 @@
-import { GitLabApiClient, ProjectIdType } from "./gitlab-api-client";
+import { GitLabApiClient, ProjectIdType, DiscussionResource } from "./gitlab-api-client";
 import { NotifyParams, PluginLogger } from "reg-suit-interface";
 import { createCommentBody } from "./create-comment";
 
@@ -76,6 +76,63 @@ export async function commentToMergeRequests({ noEmit, logger, client, notifyPar
         if (!commentedNote) {
           if (!noEmit) {
             await client.postMergeRequestNote({
+              project_id: +projectId,
+              merge_request_iid: mr.iid,
+              body: createNoteBody(notifyParams),
+            });
+          }
+        } else {
+          if (!noEmit) {
+            await client.putMergeRequestNote({
+              project_id: +projectId,
+              merge_request_iid: mr.iid,
+              note_id: commentedNote.id,
+              body: createNoteBody(notifyParams),
+            });
+          }
+        }
+        spinner.stop();
+      } catch(err) {
+        spinner.stop();
+        throw err
+      }
+    }));
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function addDiscussionToMergeRequests({ noEmit, logger, client, notifyParams, projectId }: Context) {
+  try {
+    const mrList = await client.getMergeRequests({ project_id: +projectId });
+    if (!mrList.length) {
+      logger.warn("There's no opened merge requests. Retry open some merge request including the commit " + logger.colors.green(notifyParams.actualKey));
+      return;
+    }
+    const commitsList = await Promise.all(
+      mrList.map(
+        async mr => {
+          const commits = await client.getMergeRequestCommits({ project_id: +projectId, merge_request_iid: mr.iid });
+          return { mr, commits };
+        }
+      )
+    );
+
+    const targetMrs = commitsList.filter(({ mr, commits}) => commits.some(c => c.id === notifyParams.actualKey));
+    if (!targetMrs.length) {
+      logger.warn("There's no opened merge requests including the commit " + logger.colors.green(notifyParams.actualKey) + " ...");
+      return;
+    }
+
+    await Promise.all(targetMrs.map(async ({ mr, commits }) => {
+      const notes = await client.getMergeRequestNotes({ project_id: +projectId, merge_request_iid: mr.iid });
+      const commentedNote = notes.find(note => note.body.startsWith(COMMENT_MARK));
+      const spinner = logger.getSpinner("commenting merge request" + logger.colors.magenta(mr.web_url));
+      spinner.start();
+      try {
+        if (!commentedNote) {
+          if (!noEmit) {
+            await client.postMergeRequestDiscussion({
               project_id: +projectId,
               merge_request_iid: mr.iid,
               body: createNoteBody(notifyParams),

--- a/packages/reg-notify-gitlab-plugin/test/fixtures/base-fulfilled/postMergeRequestDiscussion.json
+++ b/packages/reg-notify-gitlab-plugin/test/fixtures/base-fulfilled/postMergeRequestDiscussion.json
@@ -1,0 +1,29 @@
+{
+  "id": "2301bd5907e55d703162ea8dd565ab51ca84781f",
+  "individual_note": false,
+  "notes": [
+    {
+      "id": 86702361,
+      "type": "DiscussionNote",
+      "body": "<!-- reg-notify-gitlab-plugin posted -->\nupdated",
+      "attachment": null,
+      "author": {
+        "id": 1839429,
+        "name": "Yosuke Kurami",
+        "username": "Quramy",
+        "state": "active",
+        "avatar_url": "https://secure.gravatar.com/avatar/893f54413c2bd9ba41d11d753aacaf2c?s=80&d=identicon",
+        "web_url": "https://gitlab.com/Quramy"
+      },
+      "created_at": "2018-07-08T14:34:11.890Z",
+      "updated_at": "2018-07-08T14:34:12.986Z",
+      "system": false,
+      "noteable_id": 13813091,
+      "noteable_type": "MergeRequest",
+      "resolvable": true,
+      "resolved": false,
+      "resolved_by": null,
+      "noteable_iid": 1
+    }
+  ]
+}

--- a/packages/reg-notify-gitlab-plugin/test/fixtures/base-no-marked-comment/postMergeRequestDiscussion.json
+++ b/packages/reg-notify-gitlab-plugin/test/fixtures/base-no-marked-comment/postMergeRequestDiscussion.json
@@ -1,0 +1,29 @@
+{
+  "id": "2301bd5907e55d703162ea8dd565ab51ca84781f",
+  "individual_note": false,
+  "notes": [
+    {
+      "id": 86702361,
+      "type": "DiscussionNote",
+      "body": "<!-- reg-notify-gitlab-plugin posted -->\nupdated",
+      "attachment": null,
+      "author": {
+        "id": 1839429,
+        "name": "Yosuke Kurami",
+        "username": "Quramy",
+        "state": "active",
+        "avatar_url": "https://secure.gravatar.com/avatar/893f54413c2bd9ba41d11d753aacaf2c?s=80&d=identicon",
+        "web_url": "https://gitlab.com/Quramy"
+      },
+      "created_at": "2018-07-08T14:34:11.890Z",
+      "updated_at": "2018-07-08T14:34:12.986Z",
+      "system": false,
+      "noteable_id": 13813091,
+      "noteable_type": "MergeRequest",
+      "resolvable": true,
+      "resolved": false,
+      "resolved_by": null,
+      "noteable_iid": 1
+    }
+  ]
+}


### PR DESCRIPTION
## What does this change?
reg-notify-gitlab-plugin can select discussion comment type.

## References
gitlab discussion api
https://docs.gitlab.com/ee/api/discussions.html#create-new-merge-request-thread

