### PR TITLE
Option to show a small table instead of all the circles

### DIFF
--- a/packages/reg-notify-github-with-api-plugin/README.md
+++ b/packages/reg-notify-github-with-api-plugin/README.md
@@ -27,3 +27,9 @@ reg-suit prepare -p notify-github-with-api
 - `owner` - *Required* - GitHub owner name.
 - `repository` - *Required* - GitHub repository name.
 - `privateToken` - *Required* Private access token. The `repo` scope is required if the repository is private.
+- `shortDescription` - *Optional* Returns a small table with the item counts.
+  Example:
+
+  | 🔴 Changed | ⚪️ New | 🔵 Passing |
+  | ---        | ---    | ---        |
+  | 3          | 4      | 120        |

--- a/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
@@ -4,10 +4,10 @@ export interface CommentSeed {
   newItemsCount: number;
   deletedItemsCount: number;
   passedItemsCount: number;
+  shortDescription: boolean;
 }
 
 
-// NOTE: The following function is copied from /packages/reg-gh-app/src/pr-comment-fns.ts
 export function createCommentBody(eventBody: CommentSeed) {
   const lines: string[] = [];
   if (eventBody.failedItemsCount === 0 && eventBody.newItemsCount === 0 && eventBody.deletedItemsCount === 0) {
@@ -24,25 +24,72 @@ export function createCommentBody(eventBody: CommentSeed) {
       lines.push(`Check [this report](${eventBody.reportUrl}), and review them.`);
       lines.push("");
     }
-    lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle: "));
-    lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle: "));
-    lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle: "));
-    lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle: "));
-    lines.push("");
-    lines.push(`<details>
-                  <summary>What balls mean?</summary>
-                  The number of balls represents the number of images change detected. <br />
-                  :red_circle: : Changed items,
-                  :white_circle: : New items,
-                  :black_circle: : Deleted items, and
-                  :large_blue_circle: Passed items
-                  <br />
-               </details><br />`);
-    // lines.push(`<details>
-    //               <summary>How can I change the check status?</summary>
-    //               If reviewers accepts this differences, the reg context status will be green automatically.
-    //               <br />
-    //            </details><br />`);
+
+    if (eventBody.shortDescription) {
+      lines.push(shortDescription(eventBody));
+    } else {
+      lines.push(longDescription(eventBody));
+    }
+
+    lines.push(
+      `<details>
+          <summary>How can I change the check status?</summary>
+          If reviewers approve this PR, the reg context status will be green automatically.
+          <br />
+       </details><br />`
+    );
   }
   return lines.join("\n");
+}
+
+/**
+ * Returns a small table with the item counts.
+ *
+ * @example
+ * | 🔴 Changed | ⚪️ New | 🔵 Passing |
+ * | ---        | ---    | ---        |
+ * | 3          | 4      | 120        |
+ */
+function shortDescription({ failedItemsCount, newItemsCount, deletedItemsCount, passedItemsCount }: CommentSeed): string {
+  const descriptions = [
+    tableItem(failedItemsCount, ':red_circle:  Changed'),
+    tableItem(newItemsCount, ':white_circle:  New'),
+    tableItem(deletedItemsCount, ':black_circle:  Deleted'),
+    tableItem(passedItemsCount, ':large_blue_circle:  Passing'),
+  ];
+
+  const filteredDescriptions = descriptions.filter((item): item is [number, string] => item != null);
+
+  const headerColumns = filteredDescriptions.map(([_, header]) => header);
+  const headerDelimiter = filteredDescriptions.map(() => ' --- ');
+  const itemCount = filteredDescriptions.map(([itemCount]) => itemCount);
+
+  return `
+    | ${headerColumns.join(' | ')} |
+    | ${headerDelimiter.join(' | ')} |
+    | ${itemCount.join(' | ')} |
+  `;
+}
+
+function longDescription(eventBody: CommentSeed) {
+  const lines = [];
+  lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle: "));
+  lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle: "));
+  lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle: "));
+  lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle: "));
+  lines.push("");
+  lines.push(`<details>
+                <summary>What do the circles mean?</summary>
+                The number of circles represent the number of changed images. <br />
+                :red_circle: : Changed items,
+                :white_circle: : New items,
+                :black_circle: : Deleted items, and
+                :large_blue_circle: : Passing items
+                <br />
+             </details><br />`);
+  return lines.join('\n')
+}
+
+function tableItem(itemCount: number, header: string): [number, string] | null {
+  return itemCount == 0 ? null : [itemCount, header];
 }

--- a/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
@@ -1,4 +1,3 @@
-import * as fs from "fs";
 import * as path from "path";
 import {
   NotifierPlugin,
@@ -16,6 +15,7 @@ export interface GhApiPluginOption {
   repository: string;
   privateToken: string;
   githubUrl?: string;
+  shortDescription?: boolean;
 }
 
 export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
@@ -27,6 +27,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
   private _githubUrl!: string;
   private _token?: string;
   private _repo!: Repository;
+  private _shortDescription!: boolean;
 
   init(config: PluginCreateOptions<GhApiPluginOption>) {
     this._logger = config.logger;
@@ -35,6 +36,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
     this._githubUrl = config.options.githubUrl || "https://github.com";
     this._token = config.options.privateToken;
     this._repo = new Repository(path.join(fsUtil.prjRootDir(".git"), ".git"));
+    this._shortDescription = config.options.shortDescription || false;
   }
 
   async notify(params: NotifyParams) {
@@ -57,6 +59,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
       failedItemsCount: params.comparisonResult.diffItems.length,
       newItemsCount: params.comparisonResult.newItems.length,
       deletedItemsCount: params.comparisonResult.deletedItems.length,
+      shortDescription: this._shortDescription,
     });
     const client = new GhGqlClient(this._token, this._githubUrl);
     if (head.type !== "branch" || !head.branch) {


### PR DESCRIPTION
## What does this change?

Adds a new option to `reg-notify-github-with-api-plugin` to show a smaller description in the comment.

- `shortDescription` - *Optional* Returns a small table with the item counts.

  Example:

  | 🔴 Changed | ⚪️ New | 🔵 Passing |
  | ---        | ---    | ---        |
  | 3          | 4      | 1420        |

This is useful when the number of items grows to a point where looking
at all the circles is no longer helpful and the body of the message
gets cut halfway through an HTML tag.


## Screenshots

Before:

![image](https://user-images.githubusercontent.com/594302/92988572-8ce50800-f481-11ea-98a3-e450c2f7cd6b.png)

After:

![image](https://user-images.githubusercontent.com/594302/92988770-6758fe00-f483-11ea-9d12-98e2b97af89d.png)

