### PR TITLE
Add plugin chatwork notify

### DIFF
--- a/packages/reg-notify-chatwork-plugin/.gitignore
+++ b/packages/reg-notify-chatwork-plugin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+lib/
+e2e/report-fixture-expected/
+built_e2e/

--- a/packages/reg-notify-chatwork-plugin/.npmignore
+++ b/packages/reg-notify-chatwork-plugin/.npmignore
@@ -1,0 +1,7 @@
+yarn.lock
+lib/**/*.spec.js
+src/
+test/
+e2e/
+built_e2e/
+built/

--- a/packages/reg-notify-chatwork-plugin/README.md
+++ b/packages/reg-notify-chatwork-plugin/README.md
@@ -15,14 +15,14 @@ reg-suit prepare -p notify-chatwork
 {
   chatworkToken: string;
   roomID: string;
-  mrURL: string;
+  mrUrl: string;
   mention: string;
-  pipelineURL: string;
+  pipelineUrl: string;
 }
 ```
 
 - `chatworkToken` - _Required_ - The API token of chatwork account sending message your chatwork channel. [Chatwork API Token](https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php)
 - `roomID` - _Required_ - The room id of your chatwork channel.
-- `mrURL` - _Optional_ - The url of merge request.
+- `mrUrl` - _Optional_ - The url of merge request.
 - `mention` - _Optional_ - Ex: [toall]
-- `pipelineURL` - _Optional_ - The url of pipeline.
+- `pipelineUrl` - _Optional_ - The url of pipeline.

--- a/packages/reg-notify-chatwork-plugin/README.md
+++ b/packages/reg-notify-chatwork-plugin/README.md
@@ -1,0 +1,28 @@
+# reg-notify-chatwork-plugin
+
+A reg-suit plugin to send notification the testing result to chatwork channel.
+
+## Install
+
+```sh
+npm i reg-notify-chatwork-plugin
+reg-suit prepare -p notify-chatwork
+```
+
+## Configure
+
+```ts
+{
+  chatworkToken: string;
+  roomID: string;
+  mrURL: string;
+  mention: string;
+  pipelineURL: string;
+}
+```
+
+- `chatworkToken` - _Required_ - The API token of chatwork account sending message your chatwork channel. [Chatwork API Token](https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php)
+- `roomID` - _Required_ - The room id of your chatwork channel.
+- `mrURL` - _Optional_ - The url of merge request.
+- `mention` - _Optional_ - Ex: [toall]
+- `pipelineURL` - _Optional_ - The url of pipeline.

--- a/packages/reg-notify-chatwork-plugin/package.json
+++ b/packages/reg-notify-chatwork-plugin/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "reg-notify-chatwork-plugin",
+  "version": "0.10.9",
+  "description": "Notify reg-suit result to Chatwork channel.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo T.B.D.",
+    "prepublish": "tsc -p tsconfig.build.json"
+  },
+  "keywords": [
+    "reg",
+    "reg-suit-plugin"
+  ],
+  "author": {
+    "name": "DieuHD",
+    "email": "hoangducdieu@gmail.com"
+  },
+  "repository": "git+https://github.com/reg-viz/reg-suit.git",
+  "license": "MIT",
+  "dependencies": {
+    "request": "^2.88.2",
+    "request-promise": "^4.2.6"
+  },
+  "devDependencies": {
+    "@types/request-promise": "4.1.46",
+    "reg-suit-interface": "^0.10.9",
+    "typescript": "4.1.2"
+  }
+}

--- a/packages/reg-notify-chatwork-plugin/src/chatwork-notifier-plugin.ts
+++ b/packages/reg-notify-chatwork-plugin/src/chatwork-notifier-plugin.ts
@@ -1,0 +1,90 @@
+import { PluginCreateOptions, PluginLogger, NotifierPlugin, NotifyParams } from "reg-suit-interface";
+
+import { sendWebHook } from "./send-web-hook";
+
+export interface ChatworkNotiferPluginOptions {
+  roomID: string;
+  chatworkToken: string;
+  mention?: string;
+  message?: string;
+  mrURL?: string;
+  pipelineURL?: string;
+}
+
+export class ChatworkNotifierPlugin implements NotifierPlugin<ChatworkNotiferPluginOptions> {
+  _logger!: PluginLogger;
+  _roomID!: string;
+  _mention?: string;
+  _chatworkToken!: string;
+  _mrURL?: string;
+  _pipelineURL?: string;
+  _noEmmit!: boolean;
+
+  init(config: PluginCreateOptions<ChatworkNotiferPluginOptions>): void {
+    this._logger = config.logger;
+    this._roomID = config.options.roomID;
+    this._mention = config.options.mention;
+    this._mrURL = config.options.mrURL;
+    this._pipelineURL = config.options.pipelineURL;
+    this._chatworkToken = config.options.chatworkToken;
+    this._noEmmit = config.noEmit;
+  }
+
+  notify(params: NotifyParams): Promise<any> {
+    const message = this.createMessage(params);
+    this._logger.info(`Send to chatwork ${this._logger.colors.green(this._roomID)}.`);
+    this._logger.verbose("body to send to chatwork", message);
+    if (this._noEmmit) return Promise.resolve();
+    const spinner = this._logger.getSpinner("sending message to chatwork...");
+    spinner.start();
+    return sendWebHook({ message: message, chatworkToken: this._chatworkToken, roomID: this._roomID })
+      .then(() => spinner.stop())
+      .catch(() => spinner.stop());
+  }
+
+  createMessage(params: NotifyParams) {
+    const lines = [];
+    const emoji = this.createEmoji(params);
+    if (this._mention && this._mention.length > 0) {
+      lines.push(this._mention);
+    }
+    lines.push(`[info][title] ` + emoji + ` Reg result for ${params.actualKey} ` + emoji + `[/title]`);
+    const { passedItems, failedItems, newItems, deletedItems } = params.comparisonResult;
+    if (failedItems.length) {
+      lines.push(`🔴  ${failedItems.length} changed items.`);
+    }
+    if (newItems.length) {
+      lines.push(`⚪️  ${newItems.length} new items.`);
+    }
+    if (deletedItems.length) {
+      lines.push(`⚫️  ${deletedItems.length} deleted items.`);
+    }
+    if (passedItems.length) {
+      lines.push(`🔵  ${passedItems.length} passed items.`);
+    }
+    if (params.reportUrl) {
+      lines.push("");
+      lines.push(`▲  Report URL: ${params.reportUrl}`);
+    }
+    if (this._mrURL && this._mrURL.length > 0) {
+      lines.push("");
+      lines.push(`■  Merge Request: ${this._mrURL}`);
+    }
+    if (this._pipelineURL && this._pipelineURL.length > 0) {
+      lines.push(`■  Pipeline URL: ${this._pipelineURL}`);
+    }
+    return lines.join("\n") + ` [/info]`;
+  }
+
+  createEmoji(params: NotifyParams) {
+    const { failedItems, newItems, deletedItems } = params.comparisonResult;
+
+    if (failedItems.length) {
+      return ";(;(;(";
+    }
+    if (newItems.length || deletedItems.length) {
+      return ":^):^):^)";
+    }
+    return "(cracker)(cracker)(cracker)";
+  }
+}

--- a/packages/reg-notify-chatwork-plugin/src/chatwork-notifier-plugin.ts
+++ b/packages/reg-notify-chatwork-plugin/src/chatwork-notifier-plugin.ts
@@ -7,8 +7,8 @@ export interface ChatworkNotiferPluginOptions {
   chatworkToken: string;
   mention?: string;
   message?: string;
-  mrURL?: string;
-  pipelineURL?: string;
+  mrUrl?: string;
+  pipelineUrl?: string;
 }
 
 export class ChatworkNotifierPlugin implements NotifierPlugin<ChatworkNotiferPluginOptions> {
@@ -16,16 +16,16 @@ export class ChatworkNotifierPlugin implements NotifierPlugin<ChatworkNotiferPlu
   _roomID!: string;
   _mention?: string;
   _chatworkToken!: string;
-  _mrURL?: string;
-  _pipelineURL?: string;
+  _mrUrl?: string;
+  _pipelineUrl?: string;
   _noEmmit!: boolean;
 
   init(config: PluginCreateOptions<ChatworkNotiferPluginOptions>): void {
     this._logger = config.logger;
     this._roomID = config.options.roomID;
     this._mention = config.options.mention;
-    this._mrURL = config.options.mrURL;
-    this._pipelineURL = config.options.pipelineURL;
+    this._mrUrl = config.options.mrUrl;
+    this._pipelineUrl = config.options.pipelineUrl;
     this._chatworkToken = config.options.chatworkToken;
     this._noEmmit = config.noEmit;
   }
@@ -64,14 +64,14 @@ export class ChatworkNotifierPlugin implements NotifierPlugin<ChatworkNotiferPlu
     }
     if (params.reportUrl) {
       lines.push("");
-      lines.push(`▲  Report URL: ${params.reportUrl}`);
+      lines.push(`▲  Report Url: ${params.reportUrl}`);
     }
-    if (this._mrURL && this._mrURL.length > 0) {
+    if (this._mrUrl && this._mrUrl.length > 0) {
       lines.push("");
-      lines.push(`■  Merge Request: ${this._mrURL}`);
+      lines.push(`■  Merge Request: ${this._mrUrl}`);
     }
-    if (this._pipelineURL && this._pipelineURL.length > 0) {
-      lines.push(`■  Pipeline URL: ${this._pipelineURL}`);
+    if (this._pipelineUrl && this._pipelineUrl.length > 0) {
+      lines.push(`■  Pipeline Url: ${this._pipelineUrl}`);
     }
     return lines.join("\n") + ` [/info]`;
   }

--- a/packages/reg-notify-chatwork-plugin/src/chatwork-preparer.ts
+++ b/packages/reg-notify-chatwork-plugin/src/chatwork-preparer.ts
@@ -1,0 +1,56 @@
+import { PluginCreateOptions, PluginPreparer } from "reg-suit-interface";
+
+import { ChatworkNotiferPluginOptions } from "./chatwork-notifier-plugin";
+import { sendWebHook } from "./send-web-hook";
+
+export interface QuestionResult {
+  webhookUrl?: string;
+  chatworkToken?: string;
+  roomID?: string;
+  sendTestMessage: boolean;
+}
+
+export class ChatworkPreparer implements PluginPreparer<QuestionResult, ChatworkNotiferPluginOptions> {
+  inquire() {
+    return [
+      {
+        name: "chatworkToken",
+        type: "input",
+        message: "Chatwork Token",
+      },
+      {
+        name: "sendTestMessage",
+        type: "confirm",
+        message: "Send test message to this URL ?",
+        default: true,
+        when: ({ chatworkToken }: { chatworkToken?: string }) => !!chatworkToken,
+      },
+    ];
+  }
+
+  prepare(opt: PluginCreateOptions<QuestionResult>): Promise<ChatworkNotiferPluginOptions> {
+    const logger = opt.logger;
+    const { chatworkToken, roomID, sendTestMessage } = opt.options;
+    if (!chatworkToken || !chatworkToken.length) {
+      logger.warn(logger.colors.magenta("chatworkToken") + " is required parameter, edit this params later.");
+      return Promise.resolve({ chatworkToken: "your_chatwork_token", roomID: "" });
+    }
+    if (!roomID || !roomID.length) {
+      logger.warn(logger.colors.magenta("roomID") + " is required parameter, edit this params later.");
+      return Promise.resolve({ roomID: "your_room_id", chatworkToken: "" });
+    }
+    if (sendTestMessage) {
+      return sendWebHook({ chatworkToken: chatworkToken, message: "test message", roomID: roomID })
+        .then(() => {
+          logger.info("Send test message successfully.");
+          return { roomID: roomID, chatworkToken: chatworkToken };
+        })
+        .catch(reason => {
+          logger.error(logger.colors.red(reason.message));
+          return Promise.reject(reason.error);
+        });
+    } else {
+      return Promise.resolve({ roomID: roomID, chatworkToken: chatworkToken });
+    }
+  }
+}

--- a/packages/reg-notify-chatwork-plugin/src/chatwork-preparer.ts
+++ b/packages/reg-notify-chatwork-plugin/src/chatwork-preparer.ts
@@ -4,7 +4,6 @@ import { ChatworkNotiferPluginOptions } from "./chatwork-notifier-plugin";
 import { sendWebHook } from "./send-web-hook";
 
 export interface QuestionResult {
-  webhookUrl?: string;
   chatworkToken?: string;
   roomID?: string;
   sendTestMessage: boolean;
@@ -21,7 +20,7 @@ export class ChatworkPreparer implements PluginPreparer<QuestionResult, Chatwork
       {
         name: "sendTestMessage",
         type: "confirm",
-        message: "Send test message to this URL ?",
+        message: "Send test message to this Url ?",
         default: true,
         when: ({ chatworkToken }: { chatworkToken?: string }) => !!chatworkToken,
       },

--- a/packages/reg-notify-chatwork-plugin/src/index.ts
+++ b/packages/reg-notify-chatwork-plugin/src/index.ts
@@ -1,0 +1,12 @@
+import { NotifierPluginFactory } from "reg-suit-interface";
+import { ChatworkNotifierPlugin } from "./chatwork-notifier-plugin";
+import { ChatworkPreparer } from "./chatwork-preparer";
+
+const pluginFactory: NotifierPluginFactory = () => {
+  return {
+    notifier: new ChatworkNotifierPlugin(),
+    preparer: new ChatworkPreparer(),
+  };
+};
+
+export = pluginFactory;

--- a/packages/reg-notify-chatwork-plugin/src/send-web-hook.ts
+++ b/packages/reg-notify-chatwork-plugin/src/send-web-hook.ts
@@ -1,0 +1,20 @@
+import rp from "request-promise";
+
+export interface SendOption {
+  roomID: string;
+  message: string;
+  chatworkToken: string;
+}
+
+export function sendWebHook(opt: SendOption): Promise<any> {
+  const reqParam: rp.OptionsWithUrl = {
+    url: "https://api.chatwork.com/v2/rooms/" + opt.roomID + "/messages",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-ChatWorkToken": opt.chatworkToken,
+    },
+    body: "body=" + opt.message,
+  };
+  return (rp(reqParam) as any) as Promise<any>;
+}

--- a/packages/reg-notify-chatwork-plugin/tsconfig.build.json
+++ b/packages/reg-notify-chatwork-plugin/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "exclude": ["lib", "e2e"]
+}

--- a/packages/reg-notify-chatwork-plugin/tsconfig.json
+++ b/packages/reg-notify-chatwork-plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "reg-suit-interface": ["./reg-suit-interface/src/index.ts"]
+    }
+  },
+  "exclude": ["lib"]
+}

--- a/packages/reg-suit-cli/well-known-plugins.json
+++ b/packages/reg-suit-cli/well-known-plugins.json
@@ -21,6 +21,11 @@
     }
   },
   {
+    "name": "reg-notify-chatwork-plugin",
+    "description": "Notify reg-suit result to Chatwork channel.",
+    "metadata": {}
+  },
+  {
     "name": "reg-notify-github-with-api-plugin",
     "description": "Notify reg-suit result to GHE repository using API",
     "metadata": {}


### PR DESCRIPTION
## What does this change?
Allow push notification to Chatwork.com

Config chatwork-nofity:
```ts
{
  chatworkToken:"xxxx-x-xxxxxx";
  roomID:"123456789";
  mrUrl:"$CI_MERGE_REQUEST_PROJECT_URL/-/merge_requests/$CI_MERGE_REQUEST_IID"; // for gitlab
  mention:"[toall]";
  pipelineUrl:  "$CI_PIPELINE_URL";
}
```
## Screenshots
<img width="829" alt="Screen Shot 2020-12-16 at 11 41 49 PM" src="https://user-images.githubusercontent.com/3165692/102380542-a060bb80-3ffa-11eb-8c05-8fec74cea408.png">

