### PR TITLE
Add yarn workspace option to reg-suit init

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Publish the `compare` result and actual images to external storage with _publish
 Install and configure reg-suit and plugins into your project.
 
 - `--use-yarn` : By the default cli installs packages using `npm`. If you prefer yarn pkg, turn this option on.
+- `--use-yarn-ws` : If you use yarn workspace, turn this option on.
 
 ### `prepare` command
 

--- a/packages/reg-suit-cli/src/cli-options.ts
+++ b/packages/reg-suit-cli/src/cli-options.ts
@@ -3,7 +3,7 @@ export interface CliOptions {
   configFileName?: string;
   logLevel: "verbose" | "info" | "silent";
   noEmit: boolean;
-  npmClient: "npm" | "yarn";
+  npmClient: "npm" | "yarn" | "yarn workspace";
   plugins: string[];
   notification: boolean;
   noInstallCore: boolean;

--- a/packages/reg-suit-cli/src/cli.ts
+++ b/packages/reg-suit-cli/src/cli.ts
@@ -51,6 +51,7 @@ function createOptions() {
     .boolean("use-dev-core") // This option is used for cli developers only, so does not need help.
     .command("init", "Install and set up reg-suit and plugins into your project.", {
       useYarn: { desc: "Whether to use yarn as npm client.", boolean: true, default: false },
+      useYarnWs: { desc: "Whether to use yarn workspace.", boolean: true, default: false },
     })
     .command("prepare", "Configure installed plugin", {
       p: { alias: "plugin", array: true, desc: "Plugin name(s) you want to set up(e.g. slack-notify)." },
@@ -63,10 +64,10 @@ function createOptions() {
     })
     .wrap(120)
     .locale("en");
-  const { config, verbose, quiet, test, useYarn, plugin, useDevCore, notification } = yargs.argv;
+  const { config, verbose, quiet, test, useYarn, useYarnWs, plugin, useDevCore, notification } = yargs.argv;
   const command = yargs.argv._[0];
   const logLevel = verbose ? "verbose" : quiet ? "silent" : "info";
-  const npmClient = useYarn ? "yarn" : "npm";
+  const npmClient = useYarn || useYarnWs ? (useYarnWs ? "yarn workspace" : "yarn") : "npm";
   const plugins = (plugin || []) as string[];
   const noInstallCore = !!useDevCore;
   return {

--- a/packages/reg-suit-cli/src/package-util.ts
+++ b/packages/reg-suit-cli/src/package-util.ts
@@ -6,7 +6,7 @@ import { fsUtil } from "reg-suit-util";
 export const PLUGIN_NAME_REGEXP = /^reg-.*-plugin$/;
 const CLI_MODULE_ID = require(path.join(__dirname, "..", "package.json"))["name"] as string;
 
-export type NpmClient = "npm" | "yarn";
+export type NpmClient = "npm" | "yarn" | "yarn workspace";
 
 export class PackageUtil {
   installPackages(client: NpmClient, packageNames: string[]): Promise<string[]> {
@@ -20,6 +20,11 @@ export class PackageUtil {
       cliArguments.push("yarn");
       cliArguments.push("add");
       cliArguments.push("-D");
+    } else if (client === "yarn workspace") {
+      cliArguments.push("yarn");
+      cliArguments.push("add");
+      cliArguments.push("-D");
+      cliArguments.push("-W");
     }
     const args = [...cliArguments, ...packageNames];
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What does this change?

### Summary

Add `--useYarnWs` for yarn workspace project.

### Detail

I use `yarn workspace` in my project. When I introduce `reg-suit` to my project, `reg-suit init --useYarn` raise exception and fail to init.

This PR introduce  `useYarnWs` option for enable to generate `regconfig.json`.

## References

- None

## Screenshots

- None

## What can I check for bug fixes?

Steps to reproduce

- git clone https://github.com/reg-viz/reg-suit.git
- cd reg-suit
- yarn
- yarn add -W -D reg-suit
- reg-suit init --useYarn

Result
```
[reg-suit] info version: 0.10.12                                                
? Plugin(s) to install (bold: recommended)  reg-keygen-git-hash-plugin : Detect 
the snapshot key to be compare with using Git hash.,  reg-notify-github-plugin :
 Notify reg-suit result to GitHub repository,  reg-publish-s3-plugin : Fetch and
 publish snapshot images to AWS S3.                                             
[reg-suit] info Install dependencies to the local directory. This procedure take
s some minutes, please wait.                                                    
◶ installing dependencies with yarn...Error: Command failed: yarn add -D reg-key
gen-git-hash-plugin reg-notify-github-plugin reg-publish-s3-plugin              
error Running this command will add the dependency to the workspace root rather 
than the workspace itself, which might not be what you want - if you really mean
t it, make it explicit by running this command again with the -W flag (or --igno
re-workspace-root-check).                                                       
                                                                                
    at ChildProcess.exithandler (child_process.js:308:12)                       
    at ChildProcess.emit (events.js:314:20)                                     
    at maybeClose (internal/child_process.js:1051:16)                           
    at Socket.<anonymous> (internal/child_process.js:442:11)                    
    at Socket.emit (events.js:314:20)                                           
    at Pipe.<anonymous> (net.js:673:12) {                                       
  killed: false,                                                                
  code: 1,                                                                      
  signal: null,                                                                 
  cmd: 'yarn add -D reg-keygen-git-hash-plugin reg-notify-github-plugin reg-publ
ish-s3-plugin'                                                                  
}                                                                               
```

After

- checkout this PR's branch
- yarn bootstrap
- node packages/reg-suit-cli/lib/cli.js init --useYarnWs

```
[reg-suit] info version: 0.10.12
? Plugin(s) to install (bold: recommended)  reg-keygen-git-hash-plugin : Detect 
the snapshot key to be compare with using Git hash.,  reg-notify-github-plugin :
 Notify reg-suit result to GitHub repository,  reg-publish-s3-plugin : Fetch and
 publish snapshot images to AWS S3.
[reg-suit] info Install dependencies to the local directory. This procedure takes some minutes, please wait.
? Working directory of reg-suit. (.reg) 
```

Thank you.