### PR TITLE
fix: use quotes for parameter in 'git rev-parse'

### DIFF
--- a/packages/reg-keygen-git-hash-plugin/src/git-cmd-client.ts
+++ b/packages/reg-keygen-git-hash-plugin/src/git-cmd-client.ts
@@ -9,7 +9,7 @@ export class GitCmdClient {
 
   revParse(currentName: string) {
     if (!this._revParseHash[currentName]) {
-      this._revParseHash[currentName] = execSync(`git rev-parse ${currentName}`, { encoding: "utf8" });
+      this._revParseHash[currentName] = execSync(`git rev-parse "${currentName}"`, { encoding: "utf8" });
     }
     return this._revParseHash[currentName];
   }


### PR DESCRIPTION
## What does this change?

We are using Renovate, just like this project, to create pull requests for updating dependencies. Some of the branch names Renovate creates have parenthesis in them, e.g. `renovate/webpack-dependencies-(non-major)`. This causes issues when reg-suit is calling `git rev-parse` with the branch name, since it doesn't quote it. 

Error thrown:

```
/bin/sh: 1: Syntax error: "(" unexpected
Error: Command failed: git rev-parse renovate/webpack-dependencies-(non-major)
/bin/sh: 1: Syntax error: "(" unexpected
    at checkExecSyncError (child_process.js:616:11)
    at Object.execSync (child_process.js:652:15)
    at GitCmdClient.revParse (/builds/frontend/packages/storybook/node_modules/reg-keygen-git-hash-plugin/lib/git-cmd-client.js:14:63)
    at CommitExplorer.getCurrentCommitHash (/builds/frontend/packages/storybook/node_modules/reg-keygen-git-hash-plugin/lib/commit-explorer.js:45:35)
    at GitHashKeyGenPlugin.getActualKey (/builds/frontend/packages/storybook/node_modules/reg-keygen-git-hash-plugin/lib/index.js:33:47)
    at RegProcessor.getActualKey (/builds/frontend/packages/storybook/node_modules/reg-suit-core/lib/processor.js:105:18)
    at /builds/frontend/packages/storybook/node_modules/reg-suit-core/lib/processor.js:27:31 {
  status: 2,
  signal: null,
  output: [ null, '', '/bin/sh: 1: Syntax error: "(" unexpected\n' ],
  pid: 1607,
  stdout: '',
  stderr: '/bin/sh: 1: Syntax error: "(" unexpected\n'
}
```

This pull requests adds quote around branch name in `git-cmd-client` `revParse`.

## What can I check for bug fixes?

- Create a branch named `renovate/webpack-dependencies-(non-major)` and verify that `git rev-parse "renovate/webpack-dependencies-(non-major)"` works.
- Run reg-keygen-git-hash-plugin and verify it finds git hashes.
