### PR TITLE
fix: reg-notify-github-with-api-plugin does not work with default githubUrl

### DIFF
--- a/packages/reg-notify-github-with-api-plugin/README.md
+++ b/packages/reg-notify-github-with-api-plugin/README.md
@@ -23,7 +23,7 @@ reg-suit prepare -p notify-github-with-api
 }
 ```
 
-- `githubUrl` - _Optional_ - URL for your GitHub Enterprise. Default: `https://github.com`.
+- `githubUrl` - _Optional_ - URL for your GitHub Enterprise. Default: `https://api.github.com/graphql`.
 - `owner` - _Required_ - GitHub owner name.
 - `repository` - _Required_ - GitHub repository name.
 - `privateToken` - _Required_ Private access token. The `repo` scope is required if the repository is private.

--- a/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
@@ -28,7 +28,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
     this._logger = config.logger;
     this._owner = config.options.owner;
     this._repository = config.options.repository;
-    this._githubUrl = config.options.githubUrl || "https://github.com";
+    this._githubUrl = config.options.githubUrl || "https://api.github.com/graphql";
     this._token = config.options.privateToken;
     this._repo = new Repository(path.join(fsUtil.prjRootDir(".git"), ".git"));
     this._shortDescription = config.options.shortDescription || false;


### PR DESCRIPTION
- fix: reg-notify-github-with-api-plugin does not work with default githubUrl
- fix README

## What does this change?

reg-notify-github-with-api-plugin does not work with default githubUrl setting.
This PR fixes this problem.

## References

I see that the [E2E test](https://github.com/reg-viz/reg-suit/blob/185192f62551e63329ca09b454916460e9bd768e/packages/reg-notify-github-with-api-plugin/e2e/script.ts#L7) was already aware of this problem.

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Nothing, I'm going to write tests if required.
