### PR TITLE
Fetch all items from rather than hardcoded limit

### DIFF
--- a/packages/reg-suit-util/src/cloud-storage-util.ts
+++ b/packages/reg-suit-util/src/cloud-storage-util.ts
@@ -86,26 +86,25 @@ export abstract class AbstractPublisher {
       const contents = [] as ObjectMetadata[];
       let isTruncated: boolean = true;
       let nextMarker: string = "";
-
-      const maxLoop = 3;
-      let loop = 0;
-      while (isTruncated && loop < maxLoop) {
+      
+      do {
         let result: ObjectListResult;
+        
         try {
           result = await this.listItems(nextMarker, actualPrefix);
           const curContents = result.contents || [];
           if (curContents.length > 0) {
             Array.prototype.push.apply(contents, curContents);
           }
-          if (result.nextMarker) {
-            nextMarker = result.nextMarker;
-          }
+
+          nextMarker = result.nextMarker;
           isTruncated = result.isTruncated || false;
         } catch (e) {
+          nextMarker = '';
           reject(e);
         }
-        loop += 1;
-      }
+      } while (nextMarker);
+      
       resolve(contents);
     })
       .then(contents => {


### PR DESCRIPTION
## What does this change?

Currently the S3 plugin has a hard limit of 3000 items, based on the `maxLoop` value of `3` and the maximum object size of `1000`.

This PR replaces the hardcoded limits with a dynamic method using `do/while` so that all items are fetched regardless of the amount.

## References

- Fixes #520 

## Screenshots

N/A

## What can I check for bug fixes?

I have ran this on a project with 3362 files in S3 and it has successfully outputs the correct amount of files.

```
[reg-publish-s3-plugin] info Download 3362 files from xxxxxxxxxxx.
```
