### PR TITLE
Drop custom resolver in favor of require.resolve

### DIFF
--- a/packages/reg-suit-core/src/plugin-manager.test.ts
+++ b/packages/reg-suit-core/src/plugin-manager.test.ts
@@ -35,12 +35,10 @@ test("should return pluginHolders", () => {
 
 test("resolve locally installed module", () => {
   const pm = createPluginManager({});
-  const p = pm._resolve("reg-suit-util", path.resolve(__dirname, ".."));
-  assert.equal(p.endsWith("reg-suit-util/lib/index.js"), true);
+  expect(() => pm._loadPlugin("reg-simple-keygen-plugin")).not.toThrowError();
 });
 
 test("resolve relative path", () => {
   const pm = createPluginManager({});
-  const actual = pm._resolve("../lib/testing/dummy-plugin", __dirname);
-  assert.equal(actual, path.resolve(__dirname, "../lib/", "testing/dummy-plugin.js"));
+  expect(() => pm._loadPlugin("./lib/testing/dummy-plugin.js")).not.toThrowError();
 });

--- a/packages/reg-suit-core/src/plugin-manager.ts
+++ b/packages/reg-suit-core/src/plugin-manager.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import {
   Plugin,
   PluginPreparer,
@@ -147,26 +146,11 @@ export class PluginManager {
   /**
    * @internal
    **/
-  _resolve(name: string, base: string) {
-    if (name.startsWith(".")) {
-      return require.resolve(path.resolve(base, name));
-    } else {
-      for (let i = 0; i < 10; i++) {
-        try {
-          return require.resolve(path.resolve(base, "node_modules", name));
-        } catch (e) {
-          base = path.resolve(base, "..");
-        }
-      }
-      throw new Error("Cannot find module " + name);
-    }
-  }
-
-  private _loadPlugin(name: string) {
+  _loadPlugin(name: string) {
     let pluginFileName = null;
     const basedir = fsUtil.prjRootDir();
     try {
-      pluginFileName = this._resolve(name, basedir);
+      pluginFileName = require.resolve(name, { paths: [basedir] });
       this._logger.verbose(`Loaded plugin from ${this._logger.colors.magenta(pluginFileName)}`);
     } catch (e) {
       this._logger.error(`Failed to load plugin '${name}'`);


### PR DESCRIPTION
## What does this change?

This PR replaces `PluginManager._resolve()` wholesale with `resolve.require`. Specifically, `this._resolve(name, base)` is replaced with `require.resolve(name, {paths: [base]})` with no loss of functionality. Since Yarn patches node's `fs` module to provide PnP support, replacing calls to `this._resolve` with `require.resolve` will make `reg-suit-core` PnP-compatible.

## References

Fixes #535.

[`resolve.require()`](https://nodejs.org/docs/latest-v12.x/api/modules.html#modules_require_resolve_request_options) takes a second argument, `options`, which supports a `paths` property. `paths` is documented as:

> Paths to resolve module location from. If present, these paths are used instead of the default resolution paths, with the exception of GLOBAL_FOLDERS like `$HOME/.node_modules`, which are always included. Each of these paths is used as a starting point for the module resolution algorithm, meaning that the node_modules hierarchy is checked from this location.

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

It is now possible to use this library in a project that utilizes Yarn's Plug'n'Play module resolution
