### PR TITLE
Notify GitLab Plugin: add shortDescription option

### DIFF
--- a/packages/reg-notify-gitlab-plugin/README.md
+++ b/packages/reg-notify-gitlab-plugin/README.md
@@ -1,8 +1,8 @@
 # reg-notify-gitlab-plugin
 
-reg-suit plugin to send notification the testing result to your GitLab repository.
+reg-suit plugin to send a notification of the testing result to your GitLab repository.
 
-Installing this plugin, reg-suit comments to your Merge Request.
+Installing this plugin makes reg-suit comment to your Merge Request.
 
 ## Install
 
@@ -19,15 +19,22 @@ reg-suit prepare -p notify-gitlab
   privateToken: string;
   gitlabUrl?: string;
   commentTo?: "note" | "description" | "discussion";
+  shortDescription?: boolean;
 }
 ```
 
-- `projectId` - _Required_ - Your GitLab project id. You can get this id via `https://gitlab.com/<your-name>/<your-project-name/edit>` page.
+- `projectId` - _Required_ - Your GitLab project id. You can get this id via `https://gitlab.com/<your-name>/<your-project-name/edit>`.
 - `privateToken` - _Required_ - Your GitLab API token. If you want more detail, see [Personal access tokens doc](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 - `gitlabUrl` - _Optional_ - Set if you host your GitLab instance. Default: `https://gitlab.com`
-- `commentTo` - _Optional_ - How this plugin comments to MR. If `"note"`, it posts or puts the comment as a MR's note. if `"description"`, your MR's description gets updated. If `"discussion"`, it posts or puts the comment as a MR's _resolvable_ note. Default: `"note"`.
+- `commentTo` - _Optional_ - How this plugin comments to MR. If `"note"`, it posts or puts the comment as an MR's note. if `"description"`, your MR's description gets updated. If `"discussion"`, it posts or puts the comment as an MR's _resolvable_ note. Default: `"note"`.
+- `shortDescription` - _Optional_ Returns a small table with the item counts.
+  Example:
+
+  | 🔴 Changed | ⚪️ New | 🔵 Passing |
+  | ---------- | ------- | ---------- |
+  | 3          | 4       | 120        |
 
 ### Auto complete on GitLab CI
 
-If you run reg-suit on GitLab CI, this plugin detect `gitlabUrl` and `projectId` values from [pre-declared GitLab CI environment values](https://docs.gitlab.com/ee/ci/variables/#predefined-variables-environment-variables).
+If you run reg-suit on GitLab CI, this plugin detects `gitlabUrl` and `projectId` values from [pre-declared GitLab CI environment values](https://docs.gitlab.com/ee/ci/variables/#predefined-variables-environment-variables).
 So you can skip `projectId`

--- a/packages/reg-notify-gitlab-plugin/src/create-comment.test.ts
+++ b/packages/reg-notify-gitlab-plugin/src/create-comment.test.ts
@@ -1,0 +1,74 @@
+import assert from "assert";
+import { createCommentBody } from "./create-comment";
+
+const mockReportUrl = "https://reports-bucket-url/report.html";
+
+test("Reports nothing has changed", async () => {
+  const commentBody = createCommentBody({
+    passedItemsCount: 42,
+    failedItemsCount: 0,
+    newItemsCount: 0,
+    deletedItemsCount: 0,
+  });
+
+  assert.match(commentBody, /there is no visual difference/);
+  assert.doesNotMatch(commentBody, /reports-bucket-url/);
+});
+
+test("Reports nothing has changed with report URL", async () => {
+  const commentBody = createCommentBody({
+    reportUrl: mockReportUrl,
+    passedItemsCount: 42,
+    failedItemsCount: 0,
+    newItemsCount: 0,
+    deletedItemsCount: 0,
+  });
+
+  assert.match(commentBody, /there is no visual difference/);
+  assert.match(commentBody, /reports-bucket-url/);
+});
+
+test("Reports changes", async () => {
+  const commentBody = createCommentBody({
+    passedItemsCount: 0,
+    failedItemsCount: 42,
+    newItemsCount: 0,
+    deletedItemsCount: 0,
+  });
+
+  assert.doesNotMatch(commentBody, /there is no visual difference/);
+  assert.match(commentBody, /reg-suit detected visual differences/);
+});
+
+test("Reports changes with report URL", async () => {
+  const commentBody = createCommentBody({
+    reportUrl: mockReportUrl,
+    passedItemsCount: 0,
+    failedItemsCount: 42,
+    newItemsCount: 0,
+    deletedItemsCount: 0,
+  });
+
+  assert.match(commentBody, /reg-suit detected visual differences/);
+  assert.match(commentBody, /reports-bucket-url/);
+});
+
+test("Reports changes with an icon per difference", async () => {
+  const commentBody = createCommentBody({
+    passedItemsCount: 4,
+    failedItemsCount: 5,
+    newItemsCount: 6,
+    deletedItemsCount: 7,
+  });
+
+  // check for a 'does not match' for expected number plus one, to assert
+  // that there are no more icons than expected
+  assert.match(commentBody, new RegExp(":large_blue_circle: ".repeat(4)));
+  assert.doesNotMatch(commentBody, new RegExp(":large_blue_circle: ".repeat(5)));
+  assert.match(commentBody, new RegExp(":red_circle: ".repeat(5)));
+  assert.doesNotMatch(commentBody, new RegExp(":red_circle: ".repeat(6)));
+  assert.match(commentBody, new RegExp(":white_circle: ".repeat(6)));
+  assert.doesNotMatch(commentBody, new RegExp(":white_circle: ".repeat(7)));
+  assert.match(commentBody, new RegExp(":black_circle: ".repeat(7)));
+  assert.doesNotMatch(commentBody, new RegExp(":black_circle: ".repeat(8)));
+});

--- a/packages/reg-notify-gitlab-plugin/src/create-comment.test.ts
+++ b/packages/reg-notify-gitlab-plugin/src/create-comment.test.ts
@@ -72,3 +72,21 @@ test("Reports changes with an icon per difference", async () => {
   assert.match(commentBody, new RegExp(":black_circle: ".repeat(7)));
   assert.doesNotMatch(commentBody, new RegExp(":black_circle: ".repeat(8)));
 });
+
+test("Reports changes with a short description", async () => {
+  const commentBody = createCommentBody({
+    passedItemsCount: 0,
+    failedItemsCount: 50,
+    newItemsCount: 60,
+    deletedItemsCount: 70,
+    shortDescription: true,
+  });
+
+  assert.match(commentBody, new RegExp(":red_circle:  Changed"));
+  assert.match(commentBody, /50/);
+  assert.match(commentBody, new RegExp(":white_circle:  New"));
+  assert.match(commentBody, /60/);
+  assert.match(commentBody, new RegExp(":black_circle:  Deleted"));
+  assert.match(commentBody, /70/);
+  assert.doesNotMatch(commentBody, new RegExp(":large_blue_circle:  Passingd"));
+});

--- a/packages/reg-notify-gitlab-plugin/src/create-comment.ts
+++ b/packages/reg-notify-gitlab-plugin/src/create-comment.ts
@@ -4,9 +4,66 @@ export interface CommentSeed {
   newItemsCount: number;
   deletedItemsCount: number;
   passedItemsCount: number;
+  shortDescription?: boolean;
 }
 
-// NOTE: The following function is copied from /packages/reg-gh-app/src/pr-comment-fns.ts
+function tableItem(itemCount: number, header: string): [number, string] | null {
+  return itemCount == 0 ? null : [itemCount, header];
+}
+
+/**
+ * Returns a small table with the item counts.
+ *
+ * @example
+ * | 🔴 Changed | ⚪️ New | 🔵 Passing |
+ * | ---        | ---    | ---        |
+ * | 3          | 4      | 120        |
+ */
+function shortDescription({
+  failedItemsCount,
+  newItemsCount,
+  deletedItemsCount,
+  passedItemsCount,
+}: CommentSeed): string {
+  const descriptions = [
+    tableItem(failedItemsCount, ":red_circle:  Changed"),
+    tableItem(newItemsCount, ":white_circle:  New"),
+    tableItem(deletedItemsCount, ":black_circle:  Deleted"),
+    tableItem(passedItemsCount, ":large_blue_circle:  Passing"),
+  ];
+
+  const filteredDescriptions = descriptions.filter((item): item is [number, string] => item != null);
+
+  const headerColumns = filteredDescriptions.map(([_, header]) => header);
+  const headerDelimiter = filteredDescriptions.map(() => " --- ");
+  const itemCount = filteredDescriptions.map(([itemCount]) => itemCount);
+
+  return `
+    | ${headerColumns.join(" | ")} |
+    | ${headerDelimiter.join(" | ")} |
+    | ${itemCount.join(" | ")} |
+  `;
+}
+
+function longDescription(eventBody: CommentSeed) {
+  const lines = [];
+  lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle: "));
+  lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle: "));
+  lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle: "));
+  lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle: "));
+  lines.push("");
+  lines.push(`<details>
+                <summary>What do the circles mean?</summary>
+                The number of circles represent the number of changed images. <br />
+                :red_circle: : Changed items,
+                :white_circle: : New items,
+                :black_circle: : Deleted items, and
+                :large_blue_circle: : Passing items
+                <br />
+             </details><br />`);
+  return lines.join("\n");
+}
+
 export function createCommentBody(eventBody: CommentSeed) {
   const lines: string[] = [];
   if (eventBody.failedItemsCount === 0 && eventBody.newItemsCount === 0 && eventBody.deletedItemsCount === 0) {
@@ -23,21 +80,12 @@ export function createCommentBody(eventBody: CommentSeed) {
       lines.push(`Check [this report](${eventBody.reportUrl}), and review them.`);
       lines.push("");
     }
-    lines.push(new Array(eventBody.failedItemsCount + 1).join(":red_circle: "));
-    lines.push(new Array(eventBody.newItemsCount + 1).join(":white_circle: "));
-    lines.push(new Array(eventBody.deletedItemsCount + 1).join(":black_circle: "));
-    lines.push(new Array(eventBody.passedItemsCount + 1).join(":large_blue_circle: "));
-    lines.push("");
-    lines.push(`<details>
-                  <summary>What balls mean?</summary>
-                  The number of balls represents the number of images change detected. <br />
-                  :red_circle: : Changed items,
-                  :white_circle: : New items,
-                  :black_circle: : Deleted items, and
-                  :large_blue_circle: Passed items
-                  <br />
-               </details><br />`);
 
+    if (eventBody.shortDescription) {
+      lines.push(shortDescription(eventBody));
+    } else {
+      lines.push(longDescription(eventBody));
+    }
   }
   return lines.join("\n");
 }

--- a/packages/reg-notify-gitlab-plugin/src/create-comment.ts
+++ b/packages/reg-notify-gitlab-plugin/src/create-comment.ts
@@ -37,11 +37,7 @@ export function createCommentBody(eventBody: CommentSeed) {
                   :large_blue_circle: Passed items
                   <br />
                </details><br />`);
-    // lines.push(`<details>
-    //               <summary>How can I change the check status?</summary>
-    //               If reviewers accepts this differences, the reg context status will be green automatically.
-    //               <br />
-    //            </details><br />`);
+
   }
   return lines.join("\n");
 }

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.test.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.test.ts
@@ -195,6 +195,7 @@ test("sends notification with appendOrUpdateMergerequestsBody", async () => {
     client,
     notifyParams,
     projectId: "98765",
+    shortDescription: false,
   });
 });
 
@@ -228,6 +229,7 @@ test("sends notification with commentToMergeRequests", async () => {
     client,
     notifyParams,
     projectId: "98765",
+    shortDescription: false,
   });
 });
 
@@ -261,5 +263,6 @@ test("sends notification with addDiscussionToMergeRequests", async () => {
     client,
     notifyParams,
     projectId: "98765",
+    shortDescription: false,
   });
 });

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.test.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.test.ts
@@ -1,0 +1,265 @@
+import { GitLabNotifierPlugin } from "./gitlab-notifier-plugin";
+import { RegLogger } from "reg-suit-util";
+import { commentToMergeRequests, appendOrUpdateMergerequestsBody, addDiscussionToMergeRequests } from "./use-cases";
+import { DefaultGitLabApiClient } from "./gitlab-api-client";
+
+jest.mock("./use-cases", () => ({
+  commentToMergeRequests: jest.fn(() => true),
+  appendOrUpdateMergerequestsBody: jest.fn(() => true),
+  addDiscussionToMergeRequests: jest.fn(() => true),
+}));
+
+let notifier = new GitLabNotifierPlugin();
+
+const coreConfig = {
+  actualDir: "/actualDir",
+  workingDir: "/workingDir",
+};
+
+const workingDirs = {
+  base: "/baseDir",
+  actualDir: "/actualDir",
+  expectedDir: "/expectedDir",
+  diffDir: "/diffDir",
+};
+
+const logger = new RegLogger();
+
+const comparisonResult = {
+  actualDir: "",
+  diffDir: "",
+  expectedDir: "",
+  actualItems: [],
+  deletedItems: [],
+  diffItems: [],
+  failedItems: [],
+  expectedItems: [],
+  newItems: [],
+  passedItems: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(logger, "info").mockImplementation(() => {});
+  jest.spyOn(logger, "warn").mockImplementation(() => {});
+
+  process.env["CI_PROJECT_URL"] = "";
+  process.env["CI_PROJECT_ID"] = "";
+
+  notifier = new GitLabNotifierPlugin();
+});
+
+test("initializes without ENV vars", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+    },
+    noEmit: false,
+  });
+  expect(logger.info).not.toBeCalled();
+});
+
+test("initializes with ENV var for project URL", async () => {
+  process.env["CI_PROJECT_URL"] = "https://project-url-from-env/path";
+
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+    },
+    noEmit: false,
+  });
+
+  expect(logger.info).toBeCalledWith(expect.stringContaining("https://project-url-from-env"));
+});
+
+test("initializes with ENV var for project ID", async () => {
+  process.env["CI_PROJECT_ID"] = "12345";
+
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+    },
+    noEmit: false,
+  });
+
+  expect(logger.info).toBeCalledWith(expect.stringContaining("12345"));
+});
+
+test("initializes with config option for project URL", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+      gitlabUrl: "https://project-url-from-option/path",
+    },
+    noEmit: false,
+  });
+
+  expect(logger.info).not.toBeCalled();
+});
+
+test("initializes with config option for project ID", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+      projectId: "98765",
+    },
+    noEmit: false,
+  });
+
+  expect(logger.info).not.toBeCalled();
+});
+
+test("does not notify because project ID is missing", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxxxxxxxx",
+    },
+    noEmit: false,
+  });
+
+  notifier.notify({
+    expectedKey: "abc",
+    actualKey: "def",
+    comparisonResult,
+  });
+
+  expect(logger.warn).toBeCalledWith(expect.stringContaining("project id is needed"));
+});
+
+test("does not notify because token is missing", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "",
+      projectId: "98765",
+    },
+    noEmit: false,
+  });
+
+  notifier.notify({
+    expectedKey: "abc",
+    actualKey: "def",
+    comparisonResult,
+  });
+
+  expect(logger.warn).toBeCalledWith(expect.stringContaining("private access token is needed"));
+});
+
+test("sends notification with appendOrUpdateMergerequestsBody", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxx",
+      projectId: "98765",
+      commentTo: "description",
+    },
+    noEmit: false,
+  });
+
+  const client = new DefaultGitLabApiClient("https://gitlab.com", "xxxxx");
+
+  const notifyParams = {
+    expectedKey: "abc",
+    actualKey: "def",
+    comparisonResult,
+  };
+
+  notifier.notify(notifyParams);
+
+  expect(logger.warn).not.toBeCalled();
+  expect(appendOrUpdateMergerequestsBody).toBeCalledWith({
+    noEmit: false,
+    logger,
+    client,
+    notifyParams,
+    projectId: "98765",
+  });
+});
+
+test("sends notification with commentToMergeRequests", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxx",
+      projectId: "98765",
+      commentTo: "note",
+    },
+    noEmit: false,
+  });
+
+  const client = new DefaultGitLabApiClient("https://gitlab.com", "xxxxx");
+
+  const notifyParams = {
+    expectedKey: "abc",
+    actualKey: "def",
+    comparisonResult,
+  };
+
+  notifier.notify(notifyParams);
+
+  expect(logger.warn).not.toBeCalled();
+  expect(commentToMergeRequests).toBeCalledWith({
+    noEmit: false,
+    logger,
+    client,
+    notifyParams,
+    projectId: "98765",
+  });
+});
+
+test("sends notification with addDiscussionToMergeRequests", async () => {
+  notifier.init({
+    coreConfig,
+    workingDirs,
+    logger,
+    options: {
+      privateToken: "xxxxx",
+      projectId: "98765",
+      commentTo: "discussion",
+    },
+    noEmit: false,
+  });
+
+  const client = new DefaultGitLabApiClient("https://gitlab.com", "xxxxx");
+
+  const notifyParams = {
+    expectedKey: "abc",
+    actualKey: "def",
+    comparisonResult,
+  };
+
+  notifier.notify(notifyParams);
+
+  expect(logger.warn).not.toBeCalled();
+  expect(addDiscussionToMergeRequests).toBeCalledWith({
+    noEmit: false,
+    logger,
+    client,
+    notifyParams,
+    projectId: "98765",
+  });
+});

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-notifier-plugin.ts
@@ -8,10 +8,11 @@ export interface GitLabPluginOption {
   projectId?: string;
   privateToken: string;
   commentTo?: "note" | "description" | "discussion";
+  shortDescription?: boolean;
 }
 
 export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> {
-  naem = "reg-notify-gitlab-plugin";
+  name = "reg-notify-gitlab-plugin";
 
   private _noEmit!: boolean;
   private _logger!: PluginLogger;
@@ -19,18 +20,20 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
   private _projectId!: string | undefined;
   private _token!: string | undefined;
   private _commentTo: "note" | "description" | "discussion" = "note";
+  private _shortDescription!: boolean;
 
   init(config: PluginCreateOptions<GitLabPluginOption>) {
     this._noEmit = config.noEmit;
     this._logger = config.logger;
     this._token = config.options.privateToken;
     this._commentTo = config.options.commentTo || "note";
+    this._shortDescription = config.options.shortDescription || false;
 
     const ciProjectUrl = process.env["CI_PROJECT_URL"];
     if (ciProjectUrl && !config.options.gitlabUrl) {
       const parsedUrl = parse(ciProjectUrl);
       const gurl = parsedUrl.protocol + "//" + parsedUrl.host;
-      this._logger.info("GitLab url" + this._logger.colors.cyan(gurl) + " is detected.");
+      this._logger.info("GitLab url " + this._logger.colors.cyan(gurl) + " is detected.");
       this._gitlabUrl = gurl;
     } else {
       this._gitlabUrl = config.options.gitlabUrl || "https://gitlab.com";
@@ -62,6 +65,7 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
         client,
         notifyParams: params,
         projectId: this._projectId,
+        shortDescription: this._shortDescription,
       });
     } else if (this._commentTo === "discussion") {
       await addDiscussionToMergeRequests({
@@ -70,6 +74,7 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
         client,
         notifyParams: params,
         projectId: this._projectId,
+        shortDescription: this._shortDescription,
       });
     } else {
       await commentToMergeRequests({
@@ -78,6 +83,7 @@ export class GitLabNotifierPlugin implements NotifierPlugin<GitLabPluginOption> 
         client,
         notifyParams: params,
         projectId: this._projectId,
+        shortDescription: this._shortDescription,
       });
     }
   }


### PR DESCRIPTION
## What does this change?

It adds the option `shortDescription` to the Notify GitLab Plugin. I took the liberty of copying the implementation from the GitHub 'with API' plugin, which already did exactly what I was looking for.

I used a new config parameter for the plugin and then passed it through from the `GitLabNotifierPlugin` class to the functions in `use-cases.ts` and then to the config object for the comment function. This adds the name of the new parameter in a lot of places in those files, which may look a bit messy. However, the only alternative I could think of was adding it to the `notifyParams`. Doing that potentially impacts code in other places, which I thought was a bit overkill.

Let me know if you'd rather see it added to `notifyParams`.

In addition to the changes, I added tests to the files that I changed, covering all lines, branches, et cetera.

## References

N/A

## Screenshots

N/A

## What can I check for bug fixes?

N/A - No bugs.

The functional change is: set `shortDescription` to `true`. The comment posted to GitLab will then be a short table summary instead of a sea of coloured icons. 
