### PR TITLE
feat(reg-notify-github-plugin): support short description

### DIFF
--- a/packages/reg-notify-github-plugin/README.md
+++ b/packages/reg-notify-github-plugin/README.md
@@ -37,6 +37,7 @@ If reg-suit detects visual differences, it set the commit status failure. Someti
   prComment?: boolean;
   prCommentBehavior?: "default" | "once" | "new";
   setCommitStatus?: boolean;
+  shortDescription?: boolean;
 }
 ```
 
@@ -47,3 +48,9 @@ If reg-suit detects visual differences, it set the commit status failure. Someti
   - `"new"` : Delete existing old comment and post new comment.
   - `"once"` : Does nothing if the PR comment exists.
 - `setCommitStatus` - _Optional_ - Whether to allow reg-suit to set commit status to fail if any visual differences are detected. Default: `true`.
+- `shortDescription` - _Optional_ Returns a small table with the item counts.
+  Example:
+
+  | 🔴 Changed | ⚪️ New | 🔵 Passing |
+  | ---------- | ------- | ---------- |
+  | 3          | 4       | 120        |

--- a/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
+++ b/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
@@ -18,6 +18,7 @@ export interface GitHubPluginOption {
   prCommentBehavior?: PrCommentBehavior;
   setCommitStatus?: boolean;
   customEndpoint?: string;
+  shortDescription?: boolean;
 }
 
 interface GhAppStatusCodeError {
@@ -50,6 +51,7 @@ export class GitHubNotifierPlugin implements NotifierPlugin<GitHubPluginOption> 
   _prComment!: boolean;
   _setCommitStatus!: boolean;
   _behavior!: PrCommentBehavior;
+  _shortDescription!: boolean;
 
   _apiPrefix!: string;
   _repo!: Repository;
@@ -75,6 +77,7 @@ export class GitHubNotifierPlugin implements NotifierPlugin<GitHubPluginOption> 
     this._prComment = config.options.prComment !== false;
     this._behavior = config.options.prCommentBehavior ?? "default";
     this._setCommitStatus = config.options.setCommitStatus !== false;
+    this._shortDescription = config.options.shortDescription ?? false;
     this._apiPrefix = config.options.customEndpoint || getGhAppInfo().endpoint;
     this._repo = new Repository(path.join(fsUtil.prjRootDir(".git"), ".git"));
   }
@@ -107,7 +110,13 @@ export class GitHubNotifierPlugin implements NotifierPlugin<GitHubPluginOption> 
     };
     if (params.reportUrl) updateStatusBody.reportUrl = params.reportUrl;
     if (this._prComment) {
-      updateStatusBody.metadata = { failedItemsCount, newItemsCount, deletedItemsCount, passedItemsCount };
+      updateStatusBody.metadata = {
+        failedItemsCount,
+        newItemsCount,
+        deletedItemsCount,
+        passedItemsCount,
+        shortDescription: this._shortDescription,
+      };
     }
 
     const reqs = [];
@@ -135,6 +144,7 @@ export class GitHubNotifierPlugin implements NotifierPlugin<GitHubPluginOption> 
           newItemsCount,
           deletedItemsCount,
           passedItemsCount,
+          shortDescription: this._shortDescription,
         };
         if (params.reportUrl) prCommentBody.reportUrl = params.reportUrl;
         const commentReq: rp.OptionsWithUri = {


### PR DESCRIPTION
## What does this change?

I've ported the `reg-notify-github-with-api-plugin`'s `shortDescription` option to `reg-notify-github-plugin`.

Some checks will fail because `reg-gh-app-inteface` is not published yet. (I've confirmed these checks by overriding the dependency to my forked repository.)

## References

- original PR: https://github.com/reg-viz/reg-suit/pull/207
- corresponding PR: https://github.com/reg-viz/gh-app/pull/60
- close: https://github.com/reg-viz/reg-suit/issues/566

## Screenshots

- without `shortDescription`

![SCR-20220219-f76](https://user-images.githubusercontent.com/6854255/154791079-624a438b-dcc7-47ee-b5f4-3f369115c04d.png)

- with `shortDescription`

![SCR-20220219-fuv](https://user-images.githubusercontent.com/6854255/154791096-0011388c-5e08-4235-b822-6f728fff8927.png)

## What can I check for bug fixes?


