### PR TITLE
Fix typo in sync-expected command

### DIFF
--- a/packages/reg-suit-cli/src/cli.ts
+++ b/packages/reg-suit-cli/src/cli.ts
@@ -57,7 +57,7 @@ function createOptions() {
       p: { alias: "plugin", array: true, desc: "Plugin name(s) you want to set up(e.g. slack-notify)." },
     })
     .command("run", "Run all procedure regression testing.")
-    .command("sync-expected", "Fecth expected images into working directory.")
+    .command("sync-expected", "Fetch expected images into working directory.")
     .command("compare", "Compare actual images with expected images and creates report.")
     .command("publish", "Publish the latest comparison result in working directory.", {
       n: { alias: "notification", desc: "Send notifications with publishing", boolean: true, default: false },


### PR DESCRIPTION
## What does this change?

Fix minor typo in cli's help (see attached screenshot)

## References

N/A

## Screenshots

![2022-03-27_20-25-12](https://user-images.githubusercontent.com/8313806/160279248-4b4abd92-79d0-446f-8fe5-f2be51bba1ac.png)

## What can I check for bug fixes?

N/A
