### PR TITLE
Add enableACL option to s3-publisher-plugin

### DIFF
--- a/packages/reg-publish-s3-plugin/README.md
+++ b/packages/reg-publish-s3-plugin/README.md
@@ -45,6 +45,7 @@ aws_secret_access_key = <your-secret-key>
 ```
 
 - `bucketName` - _Required_ - AWS S3 bucket name to publish the snapshot images to.
+- `enableACL` - _Optional_ - Specifies whether ACL is enabled or not. Default `true`.
 - `acl` - _Optional_ - Specify ACL property. By default, `public-read`.
 - `sse` - _Optional_ - Specify server-side encryption property. Default `false`. If you set `true`, this plugin send with `--sse="AES256`.
 - `sseKMSKeyId` - _Optional_ - Specify server-side encryption KMS KEY ID. If provided, is passed as SSEKMSKeyId to s3.putObject.

--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -10,6 +10,7 @@ import { FileItem, RemoteFileItem, ObjectListResult, AbstractPublisher } from "r
 export interface PluginConfig {
   bucketName: string;
   pattern?: string;
+  enableACL?: boolean;
   acl?: string;
   sse?: boolean | string;
   sseKMSKeyId?: string;
@@ -80,13 +81,18 @@ export class S3PublisherPlugin extends AbstractPublisher implements PublisherPlu
         if (err) return reject(err);
         zlib.gzip(content, (err, data) => {
           if (err) return reject(err);
+
+	  // Enable ACL by default.
+	  if(this._pluginConfig.enableACL == undefined) {
+            this._pluginConfig.enableACL = true
+	  }
           const req = {
             Bucket: this._pluginConfig.bucketName,
             Key: `${key}/${item.path}`,
             Body: data,
             ContentType: item.mimeType,
             ContentEncoding: "gzip",
-            ACL: this._pluginConfig.acl || "public-read",
+            ACL: this._pluginConfig.enableACL ? this._pluginConfig.acl || "public-read" : undefined,
             SSEKMSKeyId: this._pluginConfig.sseKMSKeyId,
           } as S3.Types.PutObjectRequest;
           if (this._pluginConfig.sse) {

--- a/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
+++ b/packages/reg-publish-s3-plugin/src/s3-publisher-plugin.ts
@@ -82,10 +82,10 @@ export class S3PublisherPlugin extends AbstractPublisher implements PublisherPlu
         zlib.gzip(content, (err, data) => {
           if (err) return reject(err);
 
-	  // Enable ACL by default.
-	  if(this._pluginConfig.enableACL == undefined) {
+          // Enable ACL by default.
+          if(this._pluginConfig.enableACL == undefined) {
             this._pluginConfig.enableACL = true
-	  }
+          }
           const req = {
             Bucket: this._pluginConfig.bucketName,
             Key: `${key}/${item.path}`,


### PR DESCRIPTION
## What does this change?

AWS recommends disabling ACLs in S3, so add an option to use ACLs or not.
Default is to enable for backward compatibility.

## References

- Disabling ACLs for all new buckets and enforcing Object Ownership - https://docs.aws.amazon.com/AmazonS3/latest/userguide/ensure-object-ownership.html
