### PR TITLE
fix: pass expectedKey after syncExpected

### DIFF
--- a/packages/reg-suit-core/src/processor.ts
+++ b/packages/reg-suit-core/src/processor.ts
@@ -174,7 +174,9 @@ export class RegProcessor {
   syncExpected(ctx: StepResultAfterExpectedKey): Promise<StepResultAfterExpectedKey> {
     const keyForExpected = ctx.expectedKey;
     if (this._publisher && keyForExpected) {
-      return this._publisher.fetch(keyForExpected);
+      return this._publisher.fetch(keyForExpected).then(result => {
+        return { ...ctx, ...result };
+      });
     } else if (!keyForExpected) {
       this._logger.info("Skipped to fetch the expected data because expected key is null.");
       return Promise.resolve(ctx);


### PR DESCRIPTION
## What does this change?

I'm using own Slack Notify plugin and we want to notify `expectedKey` through it. However, currently in the `syncExpected` function in reg-suit-core, it's not passing the `ctx` argument, causing expectedKey to be lost. Therefore, I modified `syncExpected` to include the contents of the `ctx` argument in its return value.

(I thought it would be appropriate to inherit the contents of `ctx` because the return type is also `StepResultAfterExpectedKey`.)

## References

nothing

## Screenshots

nothing

## What can I check for bug fixes?

I have enabled any Publisher plugin and executed run with the --verbose flag. I checked the `"expectedKey"` log output and confirmed that it was displayed in the form of `"Notify parameters:"`.
