### PR TITLE
feat: add concurrency option for comparaison

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
 {
   actualDir: string;
   workingDir?: string;        // default ".reg"
-  thresholdRate?: number;    // default 0
+  thresholdRate?: number;     // default 0
   thresholdPixel?: number;    // default 0
-  enableAntialias?: boolean;    // default false
+  enableAntialias?: boolean;  // default false
   ximgdiff?: {
     invocationType: "none" | "client";  // default "client"
   };
+  concurrency?: number;       // default 4
 }
 ```
 
@@ -138,6 +139,7 @@ The `core` section contains reg-suit core setting and the `plugins` section cont
 - `enableAntialias` - _Optional_ - Enable antialias, so that anti-aliased pixels are detected and ignored when comparing images.
 - `ximgdiff` - _Optional_ - An option to display more detailed difference information to report html.
 - `ximgdiff.invocationType` - If set `"client"`, x-img-diff-js be invoked only with browsers. See [smart differences detection](#smart-difference-detection) section.
+- `concurrency` - _Optional_ - How many processes launches to compare in parallel.
 
 ### `plugins`
 

--- a/packages/reg-suit-core/src/processor.ts
+++ b/packages/reg-suit-core/src/processor.ts
@@ -118,6 +118,7 @@ export class RegProcessor {
       enableAntialias: this._config.enableAntialias,
       enableCliAdditionalDetection: ximgdiffConf.invocationType === "cli",
       enableClientAdditionalDetection: ximgdiffConf.invocationType !== "none",
+      concurrency: this._config.concurrency ?? 4,
     }) as EventEmitter;
     emitter.on("compare", (compareItem: { type: string; path: string }) => {
       this._logger.verbose(

--- a/packages/reg-suit-interface/src/core.ts
+++ b/packages/reg-suit-interface/src/core.ts
@@ -11,6 +11,7 @@ export interface CoreConfig {
   ximgdiff?: {
     invocationType: AdditionalDetectionInvocationType;
   };
+  concurrency?: number;
 }
 
 export interface WorkingDirectoryInfo {


### PR DESCRIPTION
## What does this change?

In `compare` command, reg-suit uses [reg-cli](https://github.com/reg-viz/reg-cli).
reg-cli provides `concurrency` option, but we couldn't set this option from reg-suit.

I added `concurrency` option to the "core" section of config.

## References

- reg-cli Options: https://github.com/reg-viz/reg-cli?tab=readme-ov-file#options

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
