### PR TITLE
docs: Modify the reg-publish-s3-plugin README to use s3:ListBucket instead of s3:ListObject

### DIFF
--- a/packages/reg-publish-s3-plugin/README.md
+++ b/packages/reg-publish-s3-plugin/README.md
@@ -47,6 +47,6 @@ This plugin needs following role policy.
     "s3:GetObjectAcl",
     "s3:PutObject",
     "s3:PutObjectAcl",
-    "s3:ListObject"
+    "s3:ListBucket"
   ]
 ```


### PR DESCRIPTION
## What does this change?

The S3 actions does not have s3:ListObject, and the s3:ListBucket is required to run ListObjects.

## References

[Actions defined by Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/list_amazons3.html#amazons3-actions-as-permissions)
