### PR TITLE
fix(reg-notify-github-with-api-plugin): fix short description style

### DIFF
--- a/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
@@ -38,11 +38,11 @@ function shortDescription({
   const headerDelimiter = filteredDescriptions.map(() => " --- ");
   const itemCount = filteredDescriptions.map(([itemCount]) => itemCount);
 
-  return `
-    | ${headerColumns.join(" | ")} |
-    | ${headerDelimiter.join(" | ")} |
-    | ${itemCount.join(" | ")} |
-  `;
+  return [
+    `| ${headerColumns.join(" | ")} |`,
+    `| ${headerDelimiter.join(" | ")} |`,
+    `| ${itemCount.join(" | ")} |`,
+  ].join("\n");
 }
 
 function longDescription(eventBody: CommentSeed) {


### PR DESCRIPTION
## What does this change?
This change addresses an issue where the `short description` in `reg-notify-github-with-api-plugin` was not being properly rendered in the PR comments. I have fixed it to ensure it displays correctly as Markdown.

## References
I referenced a similar fix made in `reg-notify-gitlab-plugin` to guide this implementation.
- https://github.com/reg-viz/reg-suit/pull/625
- It seems related to this issue: https://github.com/reg-viz/reg-suit/issues/626

## Screenshots
In my project, the comments were being displayed like this with the current package:
![screenshot](https://github.com/reg-viz/reg-suit/assets/38938327/b820a5be-61ec-47f4-a0a4-9a1f51af806f)

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.
