### PR TITLE
[Feature] Add a flag disabling to compress files to reg-gcs-publish-plugin

### DIFF
--- a/packages/reg-publish-gcs-plugin/README.md
+++ b/packages/reg-publish-gcs-plugin/README.md
@@ -22,9 +22,13 @@ If you run this plugin in your CI service, it's recommended to create a Service 
   bucketName: string;
   customUri?: string;
   pathPrefix?: string;
+  uncompressed?: boolean;
 }
 ```
 
 - `bucketName` - _Required_ - GCS bucket name to publish the snapshot images to.
 - `customUri` - _Optional_ - Custom URI prefix. Default value is `https://storage.googleapis.com/${bucketName}`. It's useful if you request report HTML over some HTTP proxy servers.
 - `pathPrefix` - _Optional_ - Specify paths. For example if you set `some_dir`, the report is published with URL such as `https://storage.googleapis.com/your-bucket/some_dir/xxxxxxxxxindex.html`.
+- `uncompressed` - _Optional_ - If you want to upload files to GCS without [gzip transcording](https://cloud.google.com/storage/docs/transcoding), specify this property as `true`. When this property is `false` or `undefined`, all files are uploaded with gzip transcording.
+  - If you try to build a private static website built by `vrt-suit` with [nginx on Cloud Run mounted GCS](https://cloud.google.com/blog/en/products/serverless/introducing-cloud-run-volume-mounts?hl=en), it's better to set the flag as `true` for the following constraint.
+    - GCS mount uses [gcsfuse](https://cloud.google.com/storage/docs/gcs-fuse?hl=ja) in the background. This tool doesn't undergo decompressive transcoding, so if you upload files with gzip transcoding, nginx delivers the files without decompressive transcoding(i.e., delivers contents compressed by gzip) and without response header `Content-Encoding: gzip`. It means that web browsers can't properly display `index.html` to users.

--- a/packages/reg-publish-gcs-plugin/src/gcs-publisher-plugin.ts
+++ b/packages/reg-publish-gcs-plugin/src/gcs-publisher-plugin.ts
@@ -10,6 +10,7 @@ export interface PluginConfig {
   pattern?: string;
   customUri?: string;
   pathPrefix?: string;
+  uncompressed?: boolean;
 }
 
 export class GcsPublisherPlugin extends AbstractPublisher implements PublisherPlugin<PluginConfig> {
@@ -60,6 +61,14 @@ export class GcsPublisherPlugin extends AbstractPublisher implements PublisherPl
     return this._pluginConfig.bucketName;
   }
 
+  protected getUncompressed(): boolean {
+    return this._pluginConfig.uncompressed ?? false;
+  }
+
+  protected getCompressed(): boolean {
+    return !this.getUncompressed();
+  }
+
   protected getLocalGlobPattern(): string | undefined {
     return this._pluginConfig.pattern;
   }
@@ -71,7 +80,7 @@ export class GcsPublisherPlugin extends AbstractPublisher implements PublisherPl
   protected async uploadItem(key: string, item: FileItem) {
     await this._gcsClient.bucket(this._pluginConfig.bucketName).upload(item.absPath, {
       destination: `${key}/${item.path}`,
-      gzip: true,
+      gzip: this.getCompressed(),
     });
     this.logger.verbose(`Uploaded from ${item.absPath} to ${key}/${item.path}`);
     return item;


### PR DESCRIPTION
## What does this change?

Add a flag disabling to compress files when uploading GCS.

## References

The motivation for this feature is here
closes https://github.com/reg-viz/reg-suit/issues/701