### PR TITLE
perf: optimize git log explore by paginating to minimize traversal

### DIFF
--- a/packages/reg-keygen-git-hash-plugin/src/commit-explorer.test.ts
+++ b/packages/reg-keygen-git-hash-plugin/src/commit-explorer.test.ts
@@ -4,6 +4,8 @@ import { CommitExplorer } from "./commit-explorer";
 import process from "process";
 import path from "path";
 
+const GIT_LOG_COUNT_PER_PAGE_FOR_TEST = 2;
+
 const rimraf = require("rimraf");
 
 process.chdir("./test");
@@ -21,12 +23,12 @@ const copyGitFiles = (name: string) => {
 //        assert.equal issue will be fixed in version using git-tiny-walker
 // test.serial("no commit", () => {
 //   copyGitFiles("no-commit");
-//   t.throws(() => new CommitExplorer().getCurrentCommitHash());
+//   t.throws(() => new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getCurrentCommitHash());
 // });
 
 test("detached head", () => {
   copyGitFiles("detached-head");
-  expect(() => new CommitExplorer().getCurrentBranchName()).toThrowError();
+  expect(() => new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getCurrentBranchName()).toThrowError();
 });
 
 /*
@@ -34,7 +36,7 @@ test("detached head", () => {
  */
 test("initial commit", () => {
   copyGitFiles("initial-commit");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   assert.equal(null, baseHash);
 });
 
@@ -44,7 +46,7 @@ test("initial commit", () => {
  */
 test("master two commits", () => {
   copyGitFiles("master-two-commits");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   assert.equal(null, baseHash);
 });
 
@@ -54,7 +56,7 @@ test("master two commits", () => {
  */
 test("after create new branch", () => {
   copyGitFiles("after-create-new-branch");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   assert.equal(null, baseHash);
 });
 
@@ -65,7 +67,7 @@ test("after create new branch", () => {
  */
 test("commit after create new branch", () => {
   copyGitFiles("commit-new-branch");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -78,7 +80,7 @@ test("commit after create new branch", () => {
  */
 test("two commits after create new branch", () => {
   copyGitFiles("two-commit-new-branch");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -95,7 +97,7 @@ test("two commits after create new branch", () => {
 */
 test("after catch up master merge", () => {
   copyGitFiles("after-catch-up-master");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -113,7 +115,7 @@ test("after catch up master merge", () => {
 */
 test("commit after merge", () => {
   copyGitFiles("commit-after-merge");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -131,7 +133,7 @@ test("commit after merge", () => {
 
 test("master to catch up branch", () => {
   copyGitFiles("master-to-catch-up-branch");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -157,7 +159,7 @@ test("master to catch up branch", () => {
 
 test("commit after catch up and merge", () => {
   copyGitFiles("commit-after-catch-up-and-merge");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -175,7 +177,7 @@ test("commit after catch up and merge", () => {
 // * first commit
 test("after merge catch up", () => {
   copyGitFiles("after-merge-catch-up");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -195,7 +197,7 @@ test("after merge catch up", () => {
 // * first commit
 test("merge catch up and commit", () => {
   copyGitFiles("merge-catch-up-then-commit");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
@@ -213,14 +215,14 @@ test("merge catch up and commit", () => {
 // * (tag: expected) init import
 test("merge multipe commit three", () => {
   copyGitFiles("merge-multipe-commit-three");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = execSync("git rev-parse expected", { encoding: "utf8" }).trim();
   assert.equal(expected, baseHash);
 });
 
 test("error patter found in reg-suit repository", () => {
   copyGitFiles("reg-suit-error-pattern");
-  const baseHash = new CommitExplorer().getBaseCommitHash();
+  const baseHash = new CommitExplorer(GIT_LOG_COUNT_PER_PAGE_FOR_TEST).getBaseCommitHash();
   const expected = "49d38a929ae3675a1c79216709c35884f0b78900";
   assert.equal(expected, baseHash);
 });

--- a/packages/reg-keygen-git-hash-plugin/src/git-cmd-client.ts
+++ b/packages/reg-keygen-git-hash-plugin/src/git-cmd-client.ts
@@ -31,8 +31,26 @@ export class GitCmdClient {
     return execSync(shellEscape(["git", "log", "--oneline", `${a}..${b}`]), { encoding: "utf8" });
   }
 
-  logGraph() {
-    return execSync('git log -n 300 --graph --pretty=format:"%h %p"', { encoding: "utf8" });
+  logGraph(
+    options?: Partial<{
+      number: number;
+      skip: number;
+    }>,
+  ) {
+    const { number = 300, skip = 0 } = options ?? {};
+    return execSync(
+      shellEscape([
+        "git",
+        "log",
+        "-n",
+        number.toString(),
+        "--skip",
+        skip.toString(),
+        "--graph",
+        "--pretty=format:%h %p",
+      ]),
+      { encoding: "utf8" },
+    );
   }
 
   mergeBase(a: string, b: string) {


### PR DESCRIPTION
## What does this change?

Thank you for this excellent product!

While evaluating this project for potential use, I noticed that determining the expected key was taking over 30sec. I believe this can be improved, so I'm submitting this PR with my proposed solution.

The current implementation retrieves 300 git commits at once and runs `git branch --contains <hash>` for each commit hash (i.e., 300 times) before checking them sequentially to find the base commit. However, in most real-world scenarios, the base commit can typically be found within the first 10-20 commits, meaning the remaining commit hash checks are largely unnecessary.

I propose implementing pagination for git log retrieval, processing 10 commits at a time. This PR doesn't modify the base commit search logic itself; instead, it simply divides the git log retrieval into batches of 10 commits and recursively fetches the next batch if the base commit isn't found.

This change should significantly improve performance in typical cases where the base commit is found within the first 10 commits, as it eliminates the need to check branch containment for the remaining 290 commits. However, in worst-case scenarios where all 300 commits need to be checked, there might be a slight performance degradation due to the pagination overhead.

## References

related: https://github.com/reg-viz/reg-suit/issues/136

## Screenshots

## What can I check for bug fixes?

While this change isn't a bug fix, I've checked that `reg-keygen-git-hash-plugin` is slow by executing following script on large repository:

```js:try_git_hash_plugin.cjs
const GitHashKeyGenPlugin = require('reg-keygen-git-hash-plugin')
const path = require('node:path')

const main = async () => {
  const baseDir = process.cwd()
  const factory = GitHashKeyGenPlugin;
  const plugin = factory().keyGenerator;
  
  plugin.init({
    workingDirs: {
      base: baseDir,
      actualDir: path.resolve(baseDir, 'actual'),
      expectedDir: path.resolve(baseDir, 'expected'),
      diffDir: path.resolve(baseDir, 'diff'),
    },
  })
  const result = await plugin.getExpectedKey()
  
  console.log('expectedKey', result)
  console.log('actualKey', await plugin.getActualKey())
}

main()
  .then(() => {
    console.log('done')
  })
  .catch((err) => {
    console.error(err)
  })
```

```bash
$ time node ./try_git_hash_plugin.cjs
expectedKey d525fe0328b38e0f7150ef0f2561d71f86abcc10
actualKey 795e10298ab9923f24a67efd289ae76f2ef87a35
done
node ./try_git_hash_plugin.cjs  8.86s user 8.44s system 45% cpu 38.232 total
```

---

I've implemented this solution as a proof of concept and all tests are passing. However, I'm not entirely confident whether the code style matches the project's conventions.

I would greatly appreciate any feedback, even minor suggestions. If my implementation significantly diverges from the project's standards, I'm open to you creating a separate PR that I can use as a reference.
