### PR TITLE
use Node.js `fetch` API instead of `undici` package

### DIFF
--- a/packages/reg-notify-chatwork-plugin/package.json
+++ b/packages/reg-notify-chatwork-plugin/package.json
@@ -17,9 +17,7 @@
   },
   "repository": "git+https://github.com/reg-viz/reg-suit.git",
   "license": "MIT",
-  "dependencies": {
-    "undici": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "reg-suit-interface": "^0.14.2",
     "typescript": "4.5.2"

--- a/packages/reg-notify-chatwork-plugin/src/send-web-hook.ts
+++ b/packages/reg-notify-chatwork-plugin/src/send-web-hook.ts
@@ -1,5 +1,3 @@
-import { fetch } from "undici";
-
 export interface SendOption {
   roomID: string;
   message: string;

--- a/packages/reg-notify-github-plugin/package.json
+++ b/packages/reg-notify-github-plugin/package.json
@@ -32,7 +32,6 @@
     "open": "^8.0.0",
     "reg-gh-app-interface": "^1.3.0",
     "reg-suit-util": "^0.14.3",
-    "tiny-commit-walker": "^1.1.2",
-    "undici": "^6.0.0"
+    "tiny-commit-walker": "^1.1.2"
   }
 }

--- a/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
+++ b/packages/reg-notify-github-plugin/src/github-notifier-plugin.ts
@@ -4,7 +4,6 @@ import { inflateRawSync } from "zlib";
 import { getGhAppInfo, BaseEventBody, CommentToPrBody, UpdateStatusBody } from "reg-gh-app-interface";
 import { fsUtil } from "reg-suit-util";
 import { NotifierPlugin, NotifyParams, PluginCreateOptions, PluginLogger } from "reg-suit-interface";
-import { fetch } from "undici";
 
 type PrCommentBehavior = "default" | "once" | "new";
 

--- a/packages/reg-notify-github-with-api-plugin/package.json
+++ b/packages/reg-notify-github-with-api-plugin/package.json
@@ -31,7 +31,6 @@
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
     "reg-suit-util": "^0.14.3",
-    "tiny-commit-walker": "^1.2.1",
-    "undici": "^6.0.0"
+    "tiny-commit-walker": "^1.2.1"
   }
 }

--- a/packages/reg-notify-github-with-api-plugin/src/gh-gql-client.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/gh-gql-client.ts
@@ -2,7 +2,6 @@ import gql from "graphql-tag";
 import { ApolloClient } from "apollo-client";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import { createHttpLink } from "apollo-link-http";
-import { fetch } from "undici";
 
 const contextQuery = gql`
   query UpdatePrCommentContext($branchName: String!, $owner: String!, $repository: String!) {

--- a/packages/reg-notify-gitlab-plugin/package.json
+++ b/packages/reg-notify-gitlab-plugin/package.json
@@ -28,7 +28,6 @@
     "typescript": "4.5.2"
   },
   "dependencies": {
-    "reg-suit-util": "^0.14.3",
-    "undici": "^6.0.0"
+    "reg-suit-util": "^0.14.3"
   }
 }

--- a/packages/reg-notify-gitlab-plugin/src/gitlab-api-client.ts
+++ b/packages/reg-notify-gitlab-plugin/src/gitlab-api-client.ts
@@ -1,5 +1,3 @@
-import { fetch } from "undici";
-
 export type ProjectIdType = number;
 export type MergeResuestIidType = number;
 export type NoteIdType = number;

--- a/packages/reg-notify-slack-plugin/package.json
+++ b/packages/reg-notify-slack-plugin/package.json
@@ -17,9 +17,7 @@
   },
   "repository": "git+https://github.com/reg-viz/reg-suit.git",
   "license": "MIT",
-  "dependencies": {
-    "undici": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "reg-suit-interface": "^0.14.2",
     "typescript": "4.5.2"

--- a/packages/reg-notify-slack-plugin/src/send-web-hook.ts
+++ b/packages/reg-notify-slack-plugin/src/send-web-hook.ts
@@ -1,5 +1,3 @@
-import { fetch } from "undici";
-
 export interface SendOption {
   webhookUrl: string;
   body: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,7 +8764,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8781,15 +8781,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -8850,7 +8841,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8863,13 +8854,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9324,11 +9308,6 @@ unbzip2-stream@1.3.3:
     buffer "^5.2.1"
     through "^2.3.8"
 
-undici@^6.0.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.20.0.tgz#3b94d967693759ea625a3b78b2097213f30405a1"
-  integrity sha512-AITZfPuxubm31Sx0vr8bteSalEbs9wQb/BOBi9FPlD9Qpd6HxZ4Q0+hI742jBhkPb4RT2v5MQzaW5VhRVyj+9A==
-
 unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
@@ -9559,7 +9538,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9572,15 +9551,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What does this change?

Use [Node.js `fetch` API](https://nodejs.org/dist/latest/docs/api/globals.html#fetch) instead of [`undici` package](https://www.npmjs.com/package/undici).

## References

The Node.js `fetch` API is [available by default since Node.js v18](https://nodejs.org/ja/blog/release/v18.0.0/#fetch-experimental), and this API became [stable in v21](https://nodejs.org/ja/blog/release/v21.0.0).

Currently, Node.js v22 is Active LTS and Node.js v18 or before are EOL.
https://github.com/nodejs/Release/blob/755d5821ca9454b91d83f51736b4dddbd7a2600c/README.md

## What can I check for bug fixes?

This change is not for bug fixes.
This change makes no degradation because Node.js `fetch` API uses `undici` package internally.
