### PR TITLE
feat(reg-notify-github-with-api-plugin): make markerComment configurable via plugin option

### DIFF
--- a/packages/reg-notify-github-with-api-plugin/README.md
+++ b/packages/reg-notify-github-with-api-plugin/README.md
@@ -22,6 +22,7 @@ reg-suit prepare -p notify-github-with-api
   privateToken: string;
   ref?: string;
   shortDescription?: boolean;
+  markerComment?: string;
 }
 ```
 
@@ -36,3 +37,5 @@ reg-suit prepare -p notify-github-with-api
   | 🔴 Changed | ⚪️ New | 🔵 Passing |
   | ---------- | ------- | ---------- |
   | 3          | 4       | 120        |
+
+- `markerComment` - _Optional_ - A unique identifier used to find and update the PR comment. Default: `"reg-comment"`. Set different values when running multiple VRT workflows on the same PR to prevent them from overwriting each other's comments.

--- a/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
@@ -12,6 +12,7 @@ export interface GhApiPluginOption {
   githubUrl?: string;
   shortDescription?: boolean;
   ref?: string;
+  markerComment?: string;
 }
 
 export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
@@ -25,6 +26,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
   private _repo!: Repository;
   private _shortDescription!: boolean;
   private _ref?: string;
+  private _markerComment?: string;
 
   init(config: PluginCreateOptions<GhApiPluginOption>) {
     this._logger = config.logger;
@@ -35,6 +37,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
     this._repo = new Repository(path.join(fsUtil.prjRootDir(".git"), ".git"));
     this._shortDescription = config.options.shortDescription || false;
     this._ref = config.options.ref;
+    this._markerComment = config.options.markerComment;
   }
 
   async notify(params: NotifyParams) {
@@ -85,6 +88,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
       repository: this._repository,
       branchName,
       body: commentBody,
+      markerComment: this._markerComment,
     });
   }
 }


### PR DESCRIPTION
## Summary

When multiple VRT workflows run on the same PR, they all use the hardcoded `"reg-comment"` marker by default. This causes each run to overwrite the previous comment, leaving only one comment on the PR at the end.

This PR adds a `markerComment` option to `reg-notify-github-with-api-plugin`, allowing users to assign a unique marker per workflow so that multiple VRT comments can coexist independently on the same PR.

## Changes

- Added `markerComment?: string` to `GhApiPluginOption` interface
- Added `_markerComment` field to `GhApiNotifierPlugin` class
- Read `markerComment` from plugin options in `init()`
- Pass `markerComment` to `client.postCommentToPr()` in `notify()`

No changes to `GhGqlClient` are needed — `postCommentToPr()` already accepts `markerComment?: string` with a default of `"reg-comment"`.

## Backward Compatibility

When `markerComment` is omitted, the existing default value `"reg-comment"` in `GhGqlClient.postCommentToPr()` is used, so there is no breaking change.

## Usage Example

```json
{
  "plugins": {
    "reg-notify-github-with-api-plugin": {
      "owner": "my-org",
      "repository": "my-repo",
      "privateToken": "...",
      "markerComment": "reg-comment-service-a"
    }
  }
}
```

With this configuration, two separate workflows can use `"reg-comment-service-a"` and `"reg-comment-service-b"` respectively, and both comments will appear independently on the same PR.