### PR TITLE
feat(reg-notify-github-with-api-plugin): add heading option

### DIFF
--- a/packages/reg-notify-github-with-api-plugin/README.md
+++ b/packages/reg-notify-github-with-api-plugin/README.md
@@ -21,6 +21,7 @@ reg-suit prepare -p notify-github-with-api
   repository: string;
   privateToken: string;
   ref?: string;
+  heading?: string;
   shortDescription?: boolean;
   markerComment?: string;
 }
@@ -31,6 +32,8 @@ reg-suit prepare -p notify-github-with-api
 - `repository` - _Required_ - GitHub repository name.
 - `privateToken` - _Required_ Private access token. The `repo` scope is required if the repository is private.
 - `ref` - _Optional_ Git branch ref value. If specified, this plugin searches PRs to comment using this value.
+- `heading` - _Optional_ - A heading displayed at the top of the PR comment. Useful when running multiple VRT workflows on the same PR to identify which workflow the result belongs to.
+
 - `shortDescription` - _Optional_ Returns a small table with the item counts.
   Example:
 

--- a/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/create-comment.ts
@@ -1,4 +1,5 @@
 export interface CommentSeed {
+  heading?: string;
   reportUrl?: string;
   failedItemsCount: number;
   newItemsCount: number;
@@ -66,6 +67,10 @@ function longDescription(eventBody: CommentSeed) {
 
 export function createCommentBody(eventBody: CommentSeed) {
   const lines: string[] = [];
+  if (eventBody.heading) {
+    lines.push(`## ${eventBody.heading}`);
+    lines.push("");
+  }
   if (eventBody.failedItemsCount === 0 && eventBody.newItemsCount === 0 && eventBody.deletedItemsCount === 0) {
     lines.push(`:sparkles: :sparkles: **That's perfect, there is no visual difference!** :sparkles: :sparkles:`);
     if (eventBody.reportUrl) {

--- a/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
+++ b/packages/reg-notify-github-with-api-plugin/src/gh-api-notifier-plugin.ts
@@ -10,6 +10,7 @@ export interface GhApiPluginOption {
   repository: string;
   privateToken: string;
   githubUrl?: string;
+  heading?: string;
   shortDescription?: boolean;
   ref?: string;
   markerComment?: string;
@@ -27,6 +28,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
   private _shortDescription!: boolean;
   private _ref?: string;
   private _markerComment?: string;
+  private _heading?: string;
 
   init(config: PluginCreateOptions<GhApiPluginOption>) {
     this._logger = config.logger;
@@ -38,6 +40,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
     this._shortDescription = config.options.shortDescription || false;
     this._ref = config.options.ref;
     this._markerComment = config.options.markerComment;
+    this._heading = config.options.heading;
   }
 
   async notify(params: NotifyParams) {
@@ -54,6 +57,7 @@ export class GhApiNotifierPlugin implements NotifierPlugin<GhApiPluginOption> {
       return;
     }
     const commentBody = createCommentBody({
+      heading: this._heading,
       reportUrl: params.reportUrl,
       passedItemsCount: params.comparisonResult.passedItems.length,
       failedItemsCount: params.comparisonResult.diffItems.length,


### PR DESCRIPTION
## What does this change?

This PR contains following changes:

- add `heading` option to `reg-notify-github-with-api-plugin` to display a visible label at the top of each PR comment
- render `heading` as `## {heading}` in the comment body
- document `heading` in README

When multiple VRT workflows run on the same PR, each workflow can post its own comment by using a unique `markerComment`. However, the comment body itself does not indicate which workflow the result belongs to. Together with `markerComment`, `heading` makes it easier to run multiple VRT workflows on the same PR.

When `heading` is omitted, comment bodies are unchanged, so there is no breaking change.

## References

- predecessor PR: https://github.com/reg-viz/reg-suit/pull/723

## Screenshots

If applicable, add screenshots to help explain your changes.

## What can I check for bug fixes?

Please briefly describe how you can confirm the resolution of the bug.