### PR TITLE
refactor: remove lodash deps

### DIFF
--- a/packages/reg-suit-util/package.json
+++ b/packages/reg-suit-util/package.json
@@ -26,14 +26,12 @@
     "@types/cli-progress": "^3.8.0",
     "@types/cli-spinner": "^0.2.0",
     "@types/glob": "^8.0.0",
-    "@types/lodash": "^4.14.161",
     "@types/mime-types": "^2.1.0",
     "@types/mkdirp": "^1.0.1",
     "chalk": "^4.1.0",
     "cli-progress": "^3.8.2",
     "cli-spinner": "^0.2.6",
     "glob": "^7.1.6",
-    "lodash": "^4.17.20",
     "mime-types": "^2.1.27",
     "mkdirp": "^1.0.4"
   }

--- a/packages/reg-suit-util/src/cloud-storage-util.ts
+++ b/packages/reg-suit-util/src/cloud-storage-util.ts
@@ -3,7 +3,6 @@ import { PluginLogger, WorkingDirectoryInfo } from "reg-suit-interface";
 
 import { lookup } from "mime-types";
 import glob from "glob";
-import _ from "lodash";
 
 export type FileItem = {
   path: string;
@@ -28,6 +27,24 @@ export type ObjectListResult = {
 
 const CONCURRENCY_SIZE = 50;
 const DEFAULT_PATTERN = "**/*.{html,js,wasm,png,json,jpeg,jpg,tiff,bmp,gif}";
+
+const chunk = <T>(arr: readonly T[], size: number): T[][] => {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error("Size must be an integer greater than zero.");
+  }
+
+  const chunkLength = Math.ceil(arr.length / size);
+  const result: T[][] = Array(chunkLength);
+
+  for (let index = 0; index < chunkLength; index++) {
+    const start = index * size;
+    const end = start + size;
+
+    result[index] = arr.slice(start, end);
+  }
+
+  return result;
+};
 
 export abstract class AbstractPublisher {
   protected noEmit = false;
@@ -121,7 +138,7 @@ export abstract class AbstractPublisher {
           } as FileItem;
         });
       })
-      .then(items => _.chunk(items, CONCURRENCY_SIZE))
+      .then(items => chunk(items, CONCURRENCY_SIZE))
       .then(chunks => {
         return chunks.reduce((acc, chunk) => {
           return acc.then(list => {
@@ -157,7 +174,7 @@ export abstract class AbstractPublisher {
             this.logger.info(`There are ${list.length} files to publish`);
           }
         }
-        return _.chunk(list, CONCURRENCY_SIZE);
+        return chunk(list, CONCURRENCY_SIZE);
       })
       .then(chunks => {
         return chunks.reduce((acc, chunk) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,11 +3023,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
-"@types/lodash@^4.14.161":
-  version "4.14.202"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
-  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
-
 "@types/mime-types@^2.1.0":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.4.tgz#93a1933e24fed4fb9e4adc5963a63efcbb3317a2"
@@ -6788,7 +6783,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8764,7 +8759,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8781,6 +8776,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -8841,7 +8845,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8854,6 +8858,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -9538,7 +9549,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9551,6 +9562,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What does this change?

Removes the `lodash` dependency from `reg-suit-util`. The only usage was `_.chunk` in `cloud-storage-util.ts`, so pulling in the entire lodash package for a single helper was unnecessary. Replaced it with a small in-file `chunk` implementation modeled after es-toolkit's `chunk`, including the same argument validation (size must be a positive integer).

Both `lodash` and `@types/lodash` are dropped from `package.json`.

This aligns with the [e18e](https://e18e.dev/) "Cleanup" initiative — replacing heavy, legacy utility libraries with lightweight modern equivalents to slim down the ecosystem's dependency graph.

## References

- e18e: https://e18e.dev/
- es-toolkit `chunk` (reference implementation): https://github.com/toss/es-toolkit/blob/main/src/array/chunk.ts

## Screenshots

N/A — internal utility refactor with no UI changes.

## What can I check for bug fixes?

This is a refactor rather than a bug fix, but behavior parity can be verified by:

- Building and testing `packages/reg-suit-util` successfully.
- Confirming that publishers extending `AbstractPublisher` (e.g. `reg-publish-s3-plugin`, `reg-publish-gcs-plugin`) still upload/fetch files in batches of `CONCURRENCY_SIZE` (50) when the file count exceeds it.
- Checking edge cases — fewer than 50 files, exactly 50 files, and an empty array — produce the same chunking as `_.chunk` did.
